### PR TITLE
Image alt tag fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,13 @@
         "drupal/entity_embed_linkit": "^1.0@beta",
         "drupal/eva": "^1.3",
         "drupal/externalauth": "^1.1",
+        "drupal/field_formatter": "^1.2",
         "drupal/field_group": "^1.0",
         "drupal/field_permissions": "^1.0@RC",
         "drupal/field_validation": "^1.0@alpha",
         "drupal/focal_point": "^1.0@beta",
         "drupal/honeypot": "^1.27",
+        "drupal/image_enhanced": "^1.0",
         "drupal/image_style_quality": "^1.3",
         "drupal/imagemagick": "^2.3",
         "drupal/libraries": "^3.0@alpha",
@@ -100,6 +102,19 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [{
+        "type": "package",
+        "package": {
+            "name": "drupal/image_enhanced",
+            "version": "1.0.0",
+            "type": "drupal-module",
+            "source": {
+                "url": "https://git.drupal.org/sandbox/blixxxa/2916732.git",
+                "type": "git",
+                "reference": "remotes/origin/8.x-1.x"
+            }
+        }
+    }],
     "extra": {
         "enable-patching": true,
         "installer-types": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2146a61c8b62d64b64f9e0d07207ee9",
+    "content-hash": "9054862de76fc5e85e1494d50f7e9c99",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -5706,6 +5706,73 @@
             }
         },
         {
+            "name": "drupal/field_formatter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/field_formatter",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/field_formatter-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "84c9468d094da49a0cb21784b41715f13cbd28fe"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1530788021",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Anybody",
+                    "homepage": "https://www.drupal.org/user/291091"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "Drupal media CI",
+                    "homepage": "https://www.drupal.org/user/3057985"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Collection of general formatters that display a single field from the referenced entity.",
+            "homepage": "https://www.drupal.org/project/field_formatter",
+            "support": {
+                "source": "http://cgit.drupalcode.org/field_formatter"
+            }
+        },
+        {
             "name": "drupal/field_group",
             "version": "1.0.0",
             "source": {
@@ -6078,6 +6145,16 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/honeypot"
             }
+        },
+        {
+            "name": "drupal/image_enhanced",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/sandbox/blixxxa/2916732.git",
+                "reference": "remotes/origin/8.x-1.x"
+            },
+            "type": "drupal-module"
         },
         {
             "name": "drupal/image_style_quality",

--- a/config/default/core.entity_view_display.media.image.quote_box_image.yml
+++ b/config/default/core.entity_view_display.media.image.quote_box_image.yml
@@ -1,0 +1,38 @@
+uuid: 9acf723c-f331-4e5c-b3e3-184b22e4f960
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.quote_box_image
+    - field.field.media.image.field_media_in_library
+    - field.field.media.image.image
+    - image.style.rectangle_horizontal_medium_350x160_
+    - media.type.image
+  module:
+    - image_enhanced
+_core:
+  default_config_hash: VLDxfMVPTkd2xvOjFMCh3kWmaOYnd03zggFXuUXQVEY
+id: media.image.quote_box_image
+targetEntityType: media
+bundle: image
+mode: quote_box_image
+content:
+  image:
+    type: image_enhanced
+    weight: 0
+    label: hidden
+    settings:
+      image_style: rectangle_horizontal_medium_350x160_
+      image_link: ''
+      custom_link: ''
+      alt_text: '[media:image:alt]'
+      title_text: '[media:name]'
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_in_library: true
+  name: true
+  scheduled_publication: true
+  thumbnail: true
+  uid: true

--- a/config/default/core.entity_view_display.node.quote_box.default.yml
+++ b/config/default/core.entity_view_display.node.quote_box.default.yml
@@ -9,10 +9,8 @@ dependencies:
     - field.field.node.quote_box.field_quote_box_quote_text
     - field.field.node.quote_box.field_quote_box_quotes
     - field.field.node.quote_box.field_quote_link
-    - image.style.rectangle_horizontal_medium_350x160_
     - node.type.quote_box
   module:
-    - media
     - name
     - options
     - panelizer
@@ -58,10 +56,10 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: rectangle_horizontal_medium_350x160_
-      image_link: ''
+      view_mode: quote_box_image
+      link: false
     third_party_settings: {  }
-    type: media_thumbnail
+    type: entity_reference_entity_view
     region: content
   field_quote_box_quote_text:
     weight: 1

--- a/config/default/core.entity_view_mode.media.quote_box_image.yml
+++ b/config/default/core.entity_view_mode.media.quote_box_image.yml
@@ -1,0 +1,14 @@
+uuid: 45442897-5209-4c2a-b1cd-8213c0239fdd
+langcode: en
+status: true
+dependencies:
+  module:
+    - lightning_core
+    - media
+third_party_settings:
+  lightning_core:
+    description: ''
+id: media.quote_box_image
+label: 'Quote Box Image'
+targetEntityType: media
+cache: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -44,6 +44,7 @@ module:
   editor: 0
   editor_advanced_link: 0
   embed: 0
+  entity: 0
   entity_block: 0
   entity_browser: 0
   entity_browser_entity_form: 0
@@ -55,6 +56,7 @@ module:
   eva: 0
   externalauth: 0
   field: 0
+  field_formatter: 0
   field_group: 0
   field_permissions: 0
   field_ui: 0
@@ -68,6 +70,7 @@ module:
   history: 0
   honeypot: 0
   image: 0
+  image_enhanced: 0
   image_widget_crop: 0
   imagemagick: 0
   inline_entity_form: 0

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -44,7 +44,6 @@ module:
   editor: 0
   editor_advanced_link: 0
   embed: 0
-  entity: 0
   entity_block: 0
   entity_browser: 0
   entity_browser_entity_form: 0


### PR DESCRIPTION
# Description

This change will fix the 'alt' image problem reported by UCOM in testing.

## Deploy Notes

This will switch quotebox from "thumbnail" to "enhanced image" display. This will enable a tokenized output of 'alt' and 'title' fields.

## Steps to Test or Reproduce

Create a quotebox and text to make sure the output has alt and title fields that match what was entered for the media node.

```shell
```
