### PR TITLE
Adds 20px gap for desktop-vertical when smaller than 1051px

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -13418,7 +13418,7 @@ article.news .news_date {
 /* line 154, ../sass/custom/_featuredcontent.scss */
 .desktop_vertical .field--items {
   display: grid;
-  grid-row-gap: 50px;
+  grid-row-gap: 20px;
   grid-template-columns: 1fr;
 }
 @media all and (min-width: 1051px) {

--- a/docroot/themes/custom/cu2017/sass/custom/_featuredcontent.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_featuredcontent.scss
@@ -153,7 +153,7 @@
 .desktop_vertical {
 	.field--items {
 		display: grid;
-		grid-row-gap: 50px;
+		grid-row-gap: 20px;
 		grid-template-columns: 1fr;
 
 		// desktop = choice of orientation


### PR DESCRIPTION
# Description

Makes the gap correct for horizontal at all sizes and vertical smaller than 1051px

## Related PRs

N/A

## Todos

- [X] Tests (Visually tested locally)
- [ ] Documentation (N/A - style change)

## Deploy Notes

N/A

## Steps to Test or Reproduce

Create a Featured Content Group with more than on item and notice the size of the gap between the items when they are displayed horizontally. The gap should be 20px.


