### PR TITLE
Changes the Rich Text Allowed HTML tags for image and video rendering in WYSIWYG

### DIFF
--- a/config/default/editor.editor.rich_text.yml
+++ b/config/default/editor.editor.rich_text.yml
@@ -64,10 +64,10 @@ settings:
             - ShowBlocks
             - RemoveFormat
   plugins:
-    language:
-      language_list: un
     stylescombo:
       styles: ''
+    language:
+      language_list: un
     linkit:
       linkit_profile: cu_default_profile
     video_embed:

--- a/config/default/filter.format.rich_text.yml
+++ b/config/default/filter.format.rich_text.yml
@@ -51,7 +51,7 @@ filters:
     status: true
     weight: -42
     settings:
-      allowed_html: '<a href hreflang name target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <br> <h1> <pre> <drupal-entity data-* title alt> <iframe src* width* height* alt* frameborder* allowfullscreen* class*> '
+      allowed_html: '<a href hreflang name target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption class* width* height* alt* title* typeof*> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <br> <h1> <pre> <drupal-entity data-* title alt> <iframe src* width* height* alt* frameborder* allowfullscreen* class*> <article class*><div class*>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:
@@ -89,6 +89,12 @@ filters:
       responsive_iframe_pattern: '#.*(youtube.|vimeo.).*#ui'
       responsive_table: '0'
       responsive_image: '0'
+  video_embed_wysiwyg:
+    id: video_embed_wysiwyg
+    provider: video_embed_wysiwyg
+    status: false
+    weight: -41
+    settings: {  }
   filter_responsive_table:
     id: filter_responsive_table
     provider: responsive_table_filter
@@ -100,10 +106,4 @@ filters:
     provider: responsive_tables_filter
     status: true
     weight: -45
-    settings: {  }
-  video_embed_wysiwyg:
-    id: video_embed_wysiwyg
-    provider: video_embed_wysiwyg
-    status: false
-    weight: -41
     settings: {  }


### PR DESCRIPTION
# Description

Embedded images and videos in the WYSIWYG rendered in Rich Text were not getting the proper wrapping or classes. The Allowed HTML tags needed to be changed to allow the same tags that are in Full HTML to also render in Rich Text.

## Related PRs

N/A
## Todos

- [x ] Tests - _This has been tested on ACSF-dev, which is where we exported the configuration from._
- [ ] Documentation - _N/A as this was more of a bug than a feature_

## Deploy Notes

This is a configuration change, so as soon as the code is pulled and database updated, it should be applied.

## Steps to Test or Reproduce
### Image
1. In any WYSIWYG with Rich Text set as the text format, add an image.
2. If you set a smaller image style and align it left or right, the text should wrap around it.
3. If you set it to full-width, it should stretch to but not beyond the width of the containing element.
### Video
1. In any WYSIWYG with Rich Text set as the text format, embed a video, using the Entity Embed button.
2. The video should stretch to but not beyond the width of the containing element.
