### PR TITLE
Fixes the image align issue when a caption is added by adding Allowed HTML Tags

### DIFF
--- a/config/default/filter.format.rich_text.yml
+++ b/config/default/filter.format.rich_text.yml
@@ -51,7 +51,7 @@ filters:
     status: true
     weight: -42
     settings:
-      allowed_html: '<a href hreflang name target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption class* width* height* alt* title* typeof*> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <br> <h1> <pre> <drupal-entity data-* title alt> <iframe src* width* height* alt* frameborder* allowfullscreen* class*> <article class*><div class*>'
+      allowed_html: '<a href hreflang name target> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption class* width* height* alt* title* typeof*> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <br> <h1> <pre> <drupal-entity data-* title alt> <iframe src* width* height* alt* frameborder* allowfullscreen* class*> <article class*><div class*> <figure role* class*> <figcaption>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:
@@ -89,12 +89,6 @@ filters:
       responsive_iframe_pattern: '#.*(youtube.|vimeo.).*#ui'
       responsive_table: '0'
       responsive_image: '0'
-  video_embed_wysiwyg:
-    id: video_embed_wysiwyg
-    provider: video_embed_wysiwyg
-    status: false
-    weight: -41
-    settings: {  }
   filter_responsive_table:
     id: filter_responsive_table
     provider: responsive_table_filter
@@ -106,4 +100,10 @@ filters:
     provider: responsive_tables_filter
     status: true
     weight: -45
+    settings: {  }
+  video_embed_wysiwyg:
+    id: video_embed_wysiwyg
+    provider: video_embed_wysiwyg
+    status: false
+    weight: -41
     settings: {  }


### PR DESCRIPTION
# Description

Image was not aligning correctly when a caption was applied

## Related PRs

[Pull #72](https://github.com/cu-webteam/d8-platform/pull/72)


## Todos

- [x ] Tests - _tested on local.creighton.edu_
- [ ] Documentation - _N/A as this is a bug_

## Deploy Notes

Update code and database.

## Steps to Test or Reproduce

1. Create a Content Page 
2. Confirm that the body is set to Rich Text
3. Add text
4. Add an image
5. Add a caption to the image
6. Align the image
7. Save
8. View the node

The text should wrap and the caption should appear under the image.

