### PR TITLE
Side nav styles

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -11326,41 +11326,52 @@ header .mega_menu_internal_main_nav .header_nav_section li a.active {
   margin: 0;
 }
 
-/* line 10, ../sass/custom/_mainnav.scss */
+/* line 20, ../sass/custom/_mainnav.scss */
 nav#block-mainnavigation {
   margin-top: 22px;
 }
 
-/* line 13, ../sass/custom/_mainnav.scss */
+/* line 25, ../sass/custom/_mainnav.scss */
+li.active.last_active.child_class a:before, li.active.last_active.grandchild_class a:before, li.active.last_active.great_grandchild_class a:before {
+  content: "•";
+  color: #FFA300;
+  padding-right: 4px;
+  font-weight: 700;
+  margin-left: -10px;
+}
+
+/* line 33, ../sass/custom/_mainnav.scss */
 .main_nav {
   padding-left: 0;
 }
-/* line 15, ../sass/custom/_mainnav.scss */
+/* line 36, ../sass/custom/_mainnav.scss */
 .main_nav .last_active a {
   font-weight: 700;
 }
-/* line 17, ../sass/custom/_mainnav.scss */
-.main_nav .last_active a:before {
+/* line 41, ../sass/custom/_mainnav.scss */
+.main_nav .child_class, .main_nav .grandchild_class, .main_nav .great_grandchild_class {
+  border-left: 2px solid #019cdb;
+  margin-left: 10px;
+  padding-left: 10px;
+}
+/* line 46, ../sass/custom/_mainnav.scss */
+.main_nav .child_class .last_active a:before, .main_nav .grandchild_class .last_active a:before, .main_nav .great_grandchild_class .last_active a:before {
   content: "•";
   color: #FFA300;
   font-size: 16px;
   padding-right: 4px;
   font-weight: 700;
+  margin-left: -9px;
 }
-/* line 25, ../sass/custom/_mainnav.scss */
-.main_nav .child_class, .main_nav .grandchild_class, .main_nav .great_grandchild_class {
-  border-left: 2px solid #019cdb;
-  margin-left: 10px;
-}
-/* line 29, ../sass/custom/_mainnav.scss */
-.main_nav .grandchild_class a {
+/* line 56, ../sass/custom/_mainnav.scss */
+.main_nav .grandchild_class {
   padding-left: 20px;
 }
-/* line 32, ../sass/custom/_mainnav.scss */
-.main_nav .great_grandchild_class a {
+/* line 59, ../sass/custom/_mainnav.scss */
+.main_nav .great_grandchild_class {
   padding-left: 40px;
 }
-/* line 36, ../sass/custom/_mainnav.scss */
+/* line 62, ../sass/custom/_mainnav.scss */
 .main_nav li {
   display: block;
   line-height: 1;
@@ -11368,7 +11379,7 @@ nav#block-mainnavigation {
   list-style-type: none;
   margin-left: 0;
 }
-/* line 43, ../sass/custom/_mainnav.scss */
+/* line 69, ../sass/custom/_mainnav.scss */
 .main_nav li a {
   font-family: "Open Sans", Arial, sans-serif;
   font-size: 16px;
@@ -11379,27 +11390,27 @@ nav#block-mainnavigation {
   text-decoration: none;
   display: block;
 }
-/* line 53, ../sass/custom/_mainnav.scss */
+/* line 79, ../sass/custom/_mainnav.scss */
 .main_nav li a:hover {
   background: #EFEFEF;
   text-decoration: none;
   width: 100%;
 }
-/* line 57, ../sass/custom/_mainnav.scss */
+/* line 83, ../sass/custom/_mainnav.scss */
 .main_nav li a.child_menu_item {
   color: #002E6D;
 }
-/* line 60, ../sass/custom/_mainnav.scss */
+/* line 86, ../sass/custom/_mainnav.scss */
 .main_nav li a.child_menu_item.active {
   font-weight: 700;
 }
-/* line 65, ../sass/custom/_mainnav.scss */
+/* line 91, ../sass/custom/_mainnav.scss */
 .main_nav li a.grandchild_menu_item {
   border-bottom: 0;
   color: #002E6D;
   font-size: 16px;
 }
-/* line 70, ../sass/custom/_mainnav.scss */
+/* line 96, ../sass/custom/_mainnav.scss */
 .main_nav li a.grandchild_menu_item.active {
   font-weight: 700;
 }

--- a/docroot/themes/custom/cu2017/sass/custom/_mainnav.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_mainnav.scss
@@ -7,24 +7,29 @@
 	text-decoration: none;
 	width:100%;
 }
+@mixin orange-indicator {
+	&:before {
+		content: "•"; 
+		color: #FFA300;
+		font-size:$baseFontSize;
+		padding-right:4px;
+		font-weight: 700;
+		margin-left: -9px;
+	}
+}
 nav#block-mainnavigation {
     margin-top: 22px;
 }
 .main_nav {
 	padding-left: 0;
-	.last_active a{
+	.child_class .last_active a {
 		@include active-link;
-		&:before {
-			content: "•"; 
-			color: #FFA300;
-			font-size:$baseFontSize;
-			padding-right:4px;
-			font-weight: 700;
-		}
+		
 	}
 	.child_class, .grandchild_class, .great_grandchild_class {
 			border-left:2px solid #019cdb;		
-			margin-left:10px;
+			margin-left:20px;
+			padding-left: 10px;
 	}
 	.grandchild_class a {
 		padding-left: 20px;

--- a/docroot/themes/custom/cu2017/sass/custom/_mainnav.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_mainnav.scss
@@ -20,24 +20,45 @@
 nav#block-mainnavigation {
     margin-top: 22px;
 }
+
+li.active.last_active.child_class, li.active.last_active.grandchild_class, li.active.last_active.great_grandchild_class{
+	 a:before{
+	content: "•";
+	color: #FFA300;
+	padding-right: 4px;
+	font-weight: 700;
+	margin-left: -10px;
+	 }
+}
 .main_nav {
 	padding-left: 0;
-	.child_class .last_active a {
+	.last_active {	
+		a {
 		@include active-link;
-		
+		}
+	
 	}
 	.child_class, .grandchild_class, .great_grandchild_class {
 			border-left:2px solid #019cdb;		
-			margin-left:20px;
+			margin-left:10px;
 			padding-left: 10px;
+			.last_active a {
+				&:before {
+					content: "•"; 
+					color: #FFA300;
+					font-size:$baseFontSize;
+					padding-right:4px;
+					font-weight: 700;
+					margin-left: -9px;
+				}
+			}
 	}
-	.grandchild_class a {
-		padding-left: 20px;
+	.grandchild_class{
+		padding-left:20px;
 	}
-	.great_grandchild_class a{
+	.great_grandchild_class{
 		padding-left: 40px;
 	}
-
 	li {
 		display: block;
 		line-height: 1;


### PR DESCRIPTION
# Description
UAT feedback changes, aligning child and grand child active list elements with inactive ones. Rather than having them indent when active. Also removing the orange • from the first level menu as an active indicator.

## Steps to Test or Reproduce
fetch the branches,
pull side-nav-styles down locally
vagrant up
vagrant ssh
visit http://local.creighton.com/about-heider-bc
click on pages on left nav, view what becomes bold and has orange •'s
