### PR TITLE
Changes spotlight template from printing node title to headline field

### DIFF
--- a/docroot/themes/custom/cu2017/templates/node/node--news-spotlight--spotlight.html.twig
+++ b/docroot/themes/custom/cu2017/templates/node/node--news-spotlight--spotlight.html.twig
@@ -10,7 +10,7 @@
             <div class="spotlight_image" id="spotlight_image">
                 {{ content.field_content_page_image.0 }}</div>
             <div class="spotlight_top_text">
-                <h2>{{ node.label }}</h2>
+                <h2>{{ node.field_content_page_headline.value }}</h2>
                 <p>{{ node.body.summary|raw|nl2br }}</p>
             </div>
         </div>


### PR DESCRIPTION
# Description

Changes spotlight template from printing node title to headline field. That way, the title can be for administrators and the headline for end-users.

## Related PRs

[78](https://github.com/cu-webteam/d8-platform/pull/78)

## Todos

- [x ] Tests - _tested on local.creighton.edu with spotlights_
- [ ] Documentation - N/A _style change_

## Deploy Notes

No DB update needed

## Steps to Test or Reproduce

Clear cache on ACSF site and check the <h1>, which should be the text in the headline.


