### PR TITLE
output from drush --include=/var/www/creighton/docroot/modules/contri…

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -25,7 +25,7 @@ drush:
 modules:
   local:
     enable: [dblog, devel, seckit, views_ui]
-    uninstall: [acquia_connector, shield, acsf]
+    uninstall: [acquia_connector, shield, acsf, acsf]
   ci:
     enable: {  }
     uninstall: [acquia_connector, shield]

--- a/composer.lock
+++ b/composer.lock
@@ -19689,17 +19689,6 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.6.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webflo/drupal-core-require-dev.git",
-                "reference": "3fa727e875f73906f7e9325619b540f7012876ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webflo/drupal-core-require-dev/zipball/3fa727e875f73906f7e9325619b540f7012876ee",
-                "reference": "3fa727e875f73906f7e9325619b540f7012876ee",
-                "shasum": ""
-            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -150,6 +150,8 @@ AddEncoding gzip svgz
   # Copy and adapt this rule to directly execute PHP files in contributed or
   # custom modules or to run another PHP application in the same directory.
   RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics.php$
+  # ACSF requirement: allow access to apc_rebuild.php.
+  RewriteCond %{REQUEST_URI} !/sites/g/apc_rebuild.php$
   # Deny access to any other PHP files that do not match the rules above.
   # Specifically, disallow autoload.php from being served directly.
   RewriteRule "^(.+/.*|autoload)\.php($|/)" - [F]

--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -13,11 +13,12 @@ if (!function_exists('acsf_hooks_includes')) {
    *   The name of the hook whose files should be returned.
    *
    * @return string[]
-   *   A list of customer-defined hook files to include.
+   *   A list of customer-defined hook files to include sorted alphabetically
+   *   ascending.
    */
   function acsf_hooks_includes($hook_name) {
     $hook_pattern = sprintf('%s/../factory-hooks/%s/*.php', getcwd(), $hook_name);
-    return glob($hook_pattern, GLOB_NOSORT);
+    return glob($hook_pattern);
   }
 }
 

--- a/drush/sites/sitecreationtest.site.yml
+++ b/drush/sites/sitecreationtest.site.yml
@@ -1,8 +1,24 @@
 01dev:
-    uri: sitecreationtest.dev-creighton.acsitefactory.com
-    host: staging-1749.enterprise-g1.hosting.acquia.com
-    options: {  }
-    paths: { dump-dir: /mnt/tmp }
-    root: /var/www/html/creighton.01dev/docroot
-    user: creighton.01dev
-    ssh: { options: '-p 22' }
+  root: /var/www/html/creighton.01dev/docroot
+  uri: sitecreationtest.dev-creighton.acsitefactory.com
+  host: staging-1749.enterprise-g1.hosting.acquia.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  user: creighton.01dev
+  ssh: { options: '-p 22' }
+01test:
+  root: /var/www/html/creighton.01test/docroot
+  uri: sitecreationtest.test-creighton.acsitefactory.com
+  host: staging-1749.enterprise-g1.hosting.acquia.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  user: creighton.01test
+  ssh: { options: '-p 22' }
+01live:
+  root: /var/www/html/creighton.01live/docroot
+  uri: sitecreationtest.creighton.acsitefactory.com
+  host: web-1747.enterprise-g1.hosting.acquia.com
+  options: {  }
+  paths: { dump-dir: /mnt/tmp }
+  user: creighton.01live
+  ssh: { options: '-p 22' }

--- a/factory-hooks/db-update/db-update.sh
+++ b/factory-hooks/db-update/db-update.sh
@@ -18,27 +18,21 @@ db_role="$3"
 domain="$4"
 
 # BLT executable:
-blt="/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt"
+blt="/var/www/html/$site.$env/vendor/acquia/blt/bin/blt"
 
 # You need the URI of the site factory website in order for drush to target that
 # site. Without it, the drush command will fail. Use the uri.php file provided by the acsf module to
 # locate the URI based on the site, environment and db role arguments.
 uri=`/usr/bin/env php /mnt/www/html/$site.$env/hooks/acquia/uri.php $site $env $db_role`
 
-# Create array with site name fragments from ACSF uri. 
+# Print a statement to the cloud log.
+echo "$site.$target_env: Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
+
 IFS='.' read -a name <<< "${uri}"
 
-# Create and set Drush cache to unique local temporary storage per site.
-# This approach isolates drush processes to completely avoid race conditions
-# that persist after initial attempts at addressing in BLT: https://github.com/acquia/blt/pull/2922
+# Set Drush cache to local ephemeral storage to avoid race conditions. This is
+# done on a per site basis to completely avoid race conditions.
+# @see https://github.com/acquia/blt/pull/2922
+export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${db_role}
 
-cacheDir=`/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri`
-
-# Print to cloud task log.
-echo "Generated temporary drush cache directory: $cacheDir."
-
-# Print to cloud task log.
-echo "Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
-
-DRUSH_PATHS_CACHE_DIRECTORY=$cacheDir $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes --no-interaction
-
+$blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes

--- a/factory-hooks/post-install/post-install.php
+++ b/factory-hooks/post-install/post-install.php
@@ -8,98 +8,20 @@
  * in your subscription. Unlike most API-based hooks, this hook does not
  * take arguments, but instead executes the PHP code it is provided.
  *
- * This is used so that an ACSF site install is identical to the local BLT site
- * install, with the environment, site, and uri CLI runtime arguments overriding
- * all other configuration.
+ * This is used so that an ACSF site install will match a local BLT site
+ * install. After a local site install, the update functions are run.
  *
  */
 
-use Drush\Drush;
-use Drupal\Component\FileCache\FileCacheFactory;
-use Drupal\Core\Database\Database;
-use Drupal\Core\Site\Settings;
+$site = $_ENV['AH_SITE_GROUP'];
+$env = $_ENV['AH_SITE_ENVIRONMENT'];
+$target_env = $site . $env;
 
-global $acsf_site_name;
+// The public domain name of the website.
+// Run updates against requested domain rather than acsf primary domain.
+$domain = $_SERVER['HTTP_HOST'];
 
-// Acquia hosting site / environment names
-/*$site = getenv('AH_SITE_GROUP');
-$env = getenv('AH_SITE_ENVIRONMENT');
-$uri = FALSE;*/
+$domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
+$site_name = array_shift($domain_fragments);
 
-$site = 'SANDBOX';
-$env = 'local';
-$uri = 'local.sandbox.com'
-
-// ACSF Database Role
-   if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
-      $db_role = $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'];
-    }
-
-$docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
-
-// BLT executable
-$blt = sprintf('/var/www/html/%s.%s/vendor/bin/blt', $site, $env);
-
-/**
- * Exit on error.
- *
- * @param string $message
- *   A message to write to sdderr.
- */
-function error($message) {
-  fwrite(STDERR, $message);
-  exit(1);
-}
-
-fwrite(STDERR, sprintf("Running updates on: site: %s; env: %s; db_role: %s; name: %s;\n", $site, $env, $db_role, $acsf_site_name));
-
-include_once $docroot . '/sites/g/sites.inc';
-$sites_json = gardens_site_data_load_file();
-if (!$sites_json) {
-  error('The ACSF site registry could not be loaded from the server.');
-}
-
-foreach ($sites_json['sites'] as $site_domain => $site_info) {
-  if ($site_info['conf']['acsf_db_name'] === $db_role && !empty($site_info['flags']['preferred_domain'])) {
-    $uri = $site_domain;
-    fwrite(STDERR, "Site domain: $uri;\n");
-    break;
-  }
-}
-if (!$uri) {
-  error('Could not find the preferred domain that belongs to the site.');
-}
-
-$docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
-
-//$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
-//cacheDir=`/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri`
-$cache_directory = exec("/mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri");
-
-shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
-
-// Execute the updates
-$command = sprintf(
-  'DRUSH_PATHS_CACHE_DIRECTORY=%s %s drupal:update --environment=%s --site=%s --define drush.uri=%s --verbose --yes --no-interaction',
-  escapeshellarg($cache_directory),
-  escapeshellarg($blt),
-  escapeshellarg($env),
-  escapeshellarg($acsf_site_name),
-  escapeshellarg($uri)
-);
-fwrite(STDERR, "Executing: $command with cache dir $cache_directory;\n");
-
-$result = 0;
-$output = array();
-exec($command, $output, $result);
-print join("\n", $output);
-
-// Clean up the drush cache directory.
-shell_exec(sprintf('rm -rf %s', escapeshellarg($cache_directory)));
-
-if ($result) {
-  fwrite(STDERR, "Command execution returned status code: $result!\n");
-  exit($result);
-}
-
-
+exec("/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt drupal:update --environment=$env --site=$site_name --define drush.uri=$domain --verbose --yes");


### PR DESCRIPTION
# Description

This is the output from the acsf_init command. ( Acquia BLT 9 – blt recipes:acsf:init:all )

Found on this page.
https://docs.acquia.com/site-factory/workflow/deployments/acsf-init/ 


```shell
```
