### PR TITLE
update config ignore to exclude richtext settins that keep changing

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -1,7 +1,8 @@
 ignored_config_entities:
   0: system.file
   2: system.site
-  4: samlauth.authentication
-  6: block.block.socialmedialinks
+  4: filter.format.rich_text
+  6: samlauth.authentication
+  8: block.block.socialmedialinks
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk


### PR DESCRIPTION
# Description

keep getting config errors on build and this is an attempt to help prevent these. According to this document https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors if the configs don't match exactly then it errors and says the import didn't work. I think this is because some configs are not imported fully because they change based on the site. 