### PR TITLE
Adds margin to copybox <p> after first

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -9709,9 +9709,13 @@ html .promo_box_wrapper {
 .copy_box_wrapper p {
   font-family: "Open Sans", Arial, sans-serif;
   font-size: 1em;
+  margin-top: 1.5em;
+}
+/* line 7, ../sass/custom/_copybox.scss */
+.copy_box_wrapper p:first-of-type {
   margin: 0;
 }
-/* line 8, ../sass/custom/_copybox.scss */
+/* line 11, ../sass/custom/_copybox.scss */
 .copy_box_wrapper hr {
   background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3C!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0%29 --%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 6.8 6.8' style='enable-background:new 0 0 6.8 6.8;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2395D2F3;%7D%0A%3C/style%3E%3Ccircle class='st0' cx='3.4' cy='3.4' r='1.5'/%3E%3C/svg%3E%0A");
   background-repeat: repeat-x;
@@ -9722,7 +9726,7 @@ html .promo_box_wrapper {
   margin: .5em 0 1em;
   width: 100%;
 }
-/* line 19, ../sass/custom/_copybox.scss */
+/* line 22, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .callout_green {
   color: #73B865;
   font-family: "Open Sans Condensed", sans-serif;
@@ -9731,22 +9735,22 @@ html .promo_box_wrapper {
   padding: 0;
   position: relative;
 }
-/* line 27, ../sass/custom/_copybox.scss */
+/* line 30, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .callout_green a {
   text-decoration: underline;
 }
-/* line 31, ../sass/custom/_copybox.scss */
+/* line 34, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .callout_green p {
   font-family: "Open Sans Condensed", sans-serif;
   font-size: 26px;
   font-weight: 700;
   text-transform: uppercase;
 }
-/* line 37, ../sass/custom/_copybox.scss */
+/* line 40, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .callout_green p a {
   color: #73B865;
 }
-/* line 43, ../sass/custom/_copybox.scss */
+/* line 46, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .upcoming_events {
   color: #019CDB;
   font-family: "Open Sans", Arial, sans-serif;
@@ -9754,27 +9758,27 @@ html .promo_box_wrapper {
   font-weight: normal;
   line-height: 1em;
 }
-/* line 50, ../sass/custom/_copybox.scss */
+/* line 53, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .upcoming_events h3 {
   color: #002E6D;
   font-weight: 700;
   margin: 0;
 }
-/* line 56, ../sass/custom/_copybox.scss */
+/* line 59, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .upcoming_events p {
   color: #555;
   font-family: "Open Sans", Arial, sans-serif;
   font-size: 16px;
   margin: 0;
 }
-/* line 63, ../sass/custom/_copybox.scss */
+/* line 66, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .upcoming_events a {
   color: #555;
   font-family: "Open Sans", Arial, sans-serif;
   font-size: 17px;
   text-decoration: underline;
 }
-/* line 71, ../sass/custom/_copybox.scss */
+/* line 74, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us {
   background-color: #002E6D;
   color: #FFF;
@@ -9782,34 +9786,34 @@ html .promo_box_wrapper {
   line-height: 1.2em;
   padding: 10px;
 }
-/* line 78, ../sass/custom/_copybox.scss */
+/* line 81, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us p {
   line-height: 1.4em;
   margin: 0 0 0.18em;
 }
-/* line 83, ../sass/custom/_copybox.scss */
+/* line 86, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us a {
   color: #FFF;
   text-decoration: underline;
   white-space: nowrap;
 }
-/* line 88, ../sass/custom/_copybox.scss */
+/* line 91, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us a:hover, .copy_box_wrapper .contact_us a:focus, .copy_box_wrapper .contact_us a:active, .copy_box_wrapper .contact_us a:visited {
   text-decoration: underline;
 }
-/* line 96, ../sass/custom/_copybox.scss */
+/* line 99, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us h3 {
   color: #FFF;
   margin-top: 0;
 }
-/* line 101, ../sass/custom/_copybox.scss */
+/* line 104, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .contact_us strong {
   font-family: "Open Sans", Arial, sans-serif;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: 1px;
 }
-/* line 109, ../sass/custom/_copybox.scss */
+/* line 112, ../sass/custom/_copybox.scss */
 .copy_box_wrapper .field--name-field-copy-box-display-type {
   display: none;
 }

--- a/docroot/themes/custom/cu2017/sass/custom/_copybox.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_copybox.scss
@@ -2,6 +2,9 @@
 	p {
 		font-family: $baseFont;
 		font-size: 1em;
+		margin-top: 1.5em;
+	}
+	p:first-of-type {
 		margin: 0;
 	}
 


### PR DESCRIPTION
# Description

Copybox needed a top margin for all but the first paragraph. I don't think we anticipated multiple paragraphs in copybox, but this is happening in panelized pages.

## Related PRs

List related PRs against other branches:
https://github.com/cu-webteam/d8-platform/pull/112

## Todos

- [x ] Tests - inspected visually on local.creighton.com
- [x ] Documentation - style changes don't _need_ documentation, do they?

## Deploy Notes

N/A

## Steps to Test or Reproduce

Check a copybox with multiple <p> tags.
All but the first should have a top margin.
