### PR TITLE
Front page fixes

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -13831,13 +13831,13 @@ article.news .news_date {
 @media all and (max-width: 480px) {
   /* line 105, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
-    margin-bottom: 80px;
+    margin-bottom: 40px;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
   /* line 105, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
-    margin-bottom: 80px;
+    margin-bottom: 40px;
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
@@ -13862,45 +13862,51 @@ article.news .news_date {
     max-width: 386px;
   }
 }
-/* line 136, ../sass/custom/_frontpage.scss */
+@media all and (max-width: 480px) {
+  /* line 134, ../sass/custom/_frontpage.scss */
+  .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image {
+    width: 460px;
+  }
+}
+/* line 138, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
   object-fit: cover;
 }
 @media all and (max-width: 480px) {
-  /* line 136, ../sass/custom/_frontpage.scss */
+  /* line 138, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 92vw;
     height: 41vw;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 136, ../sass/custom/_frontpage.scss */
+  /* line 138, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 38vw;
     height: 17vw;
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 136, ../sass/custom/_frontpage.scss */
+  /* line 138, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     max-width: 282px;
     height: 128px;
   }
 }
 @media all and (min-width: 1051px) {
-  /* line 136, ../sass/custom/_frontpage.scss */
+  /* line 138, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 30vw;
     height: 180px;
   }
 }
-/* line 156, ../sass/custom/_frontpage.scss */
+/* line 158, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
   padding: 10px 0;
   margin-right: 30px;
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 156, ../sass/custom/_frontpage.scss */
+  /* line 158, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
     margin-left: 40px;
     width: 49vw;
@@ -13908,46 +13914,46 @@ article.news .news_date {
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 156, ../sass/custom/_frontpage.scss */
+  /* line 158, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
     margin-left: 80px;
     margin-top: -15px;
   }
 }
-/* line 174, ../sass/custom/_frontpage.scss */
+/* line 176, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link {
   margin-bottom: 10px;
 }
-/* line 176, ../sass/custom/_frontpage.scss */
+/* line 178, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
   text-decoration: none;
   text-transform: none;
   line-height: 1.0em;
 }
 @media all and (min-width: 1051px) {
-  /* line 176, ../sass/custom/_frontpage.scss */
+  /* line 178, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
     margin-top: 18px;
   }
 }
-/* line 187, ../sass/custom/_frontpage.scss */
+/* line 189, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a {
   text-decoration: none;
   text-transform: none;
 }
-/* line 191, ../sass/custom/_frontpage.scss */
+/* line 193, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a:hover li {
   color: #002E6D;
 }
-/* line 200, ../sass/custom/_frontpage.scss */
+/* line 202, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_body {
   color: #555;
 }
-/* line 203, ../sass/custom/_frontpage.scss */
+/* line 205, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links {
   display: flex;
 }
-/* line 206, ../sass/custom/_frontpage.scss */
+/* line 208, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a {
   font-family: "Open Sans Condensed", sans-serif;
   font-weight: 700;
@@ -13955,7 +13961,7 @@ article.news .news_date {
   text-transform: uppercase;
   text-decoration: none;
 }
-/* line 212, ../sass/custom/_frontpage.scss */
+/* line 214, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li {
   background-image: url(../images/png/orange-arrow.png);
   background-position: 100%;
@@ -13965,68 +13971,68 @@ article.news .news_date {
   margin-top: 10px;
   display: inline-flex;
 }
-/* line 220, ../sass/custom/_frontpage.scss */
+/* line 222, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li:hover {
   color: #002E6D;
   background-image: url(../images/png/dkblue-arrow.png);
 }
 
 @media (max-width: 480px) {
-  /* line 240, ../sass/custom/_frontpage.scss */
+  /* line 242, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-top {
     margin-top: -32px;
   }
-  /* line 244, ../sass/custom/_frontpage.scss */
+  /* line 246, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper {
     height: 100%;
   }
-  /* line 246, ../sass/custom/_frontpage.scss */
+  /* line 248, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_image_wrapper {
     height: 155px;
     overflow: hidden;
   }
-  /* line 250, ../sass/custom/_frontpage.scss */
+  /* line 252, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper {
     background-color: #616161 !important;
     padding-left: 20px;
   }
-  /* line 253, ../sass/custom/_frontpage.scss */
+  /* line 255, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text {
     position: relative;
     padding-left: 40px;
   }
-  /* line 256, ../sass/custom/_frontpage.scss */
+  /* line 258, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-top: 0;
     font-weight: 400;
   }
-  /* line 260, ../sass/custom/_frontpage.scss */
+  /* line 262, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text a {
     font-weight: 400;
     font-weight: normal;
   }
-  /* line 267, ../sass/custom/_frontpage.scss */
+  /* line 269, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows, .front-page-classic .slick-arrow {
     display: none !important;
   }
-  /* line 273, ../sass/custom/_frontpage.scss */
+  /* line 275, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 278, ../sass/custom/_frontpage.scss */
+  /* line 280, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
     margin-bottom: 25px;
   }
-  /* line 280, ../sass/custom/_frontpage.scss */
+  /* line 282, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left img, .front-page-classic #row_3 .middle-center img, .front-page-classic #row_3 .middle-right img {
     width: 99%;
   }
-  /* line 284, ../sass/custom/_frontpage.scss */
+  /* line 286, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left p, .front-page-classic #row_3 .middle-center p, .front-page-classic #row_3 .middle-right p {
     font-size: 18px;
     margin-bottom: 10px;
   }
-  /* line 288, ../sass/custom/_frontpage.scss */
+  /* line 290, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left a, .front-page-classic #row_3 .middle-center a, .front-page-classic #row_3 .middle-right a {
     font-family: "Open Sans Condensed", sans-serif;
     font-weight: 700;
@@ -14038,116 +14044,116 @@ article.news .news_date {
     text-transform: uppercase;
     text-decoration: none;
   }
-  /* line 301, ../sass/custom/_frontpage.scss */
+  /* line 303, ../sass/custom/_frontpage.scss */
   .front-page-classic > div {
     padding-left: 0 !important;
   }
 }
 @media (min-width: 481px) and (max-width: 768px) {
-  /* line 310, ../sass/custom/_frontpage.scss */
+  /* line 312, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 256px;
   }
-  /* line 312, ../sass/custom/_frontpage.scss */
+  /* line 314, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 256px;
   }
-  /* line 314, ../sass/custom/_frontpage.scss */
+  /* line 316, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper {
     height: 256px;
     overflow: hidden;
   }
-  /* line 317, ../sass/custom/_frontpage.scss */
+  /* line 319, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 256px !important;
   }
-  /* line 321, ../sass/custom/_frontpage.scss */
+  /* line 323, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper {
     max-width: 768px;
     min-width: 480px;
   }
-  /* line 325, ../sass/custom/_frontpage.scss */
+  /* line 327, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text {
     padding-left: 40px;
   }
-  /* line 327, ../sass/custom/_frontpage.scss */
+  /* line 329, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-bottom: 0;
   }
-  /* line 338, ../sass/custom/_frontpage.scss */
+  /* line 340, ../sass/custom/_frontpage.scss */
   .front-page-classic .featured_content_image img {
     display: flex;
     float: left;
     width: 42%;
   }
-  /* line 345, ../sass/custom/_frontpage.scss */
+  /* line 347, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
     margin-bottom: 20px;
   }
-  /* line 347, ../sass/custom/_frontpage.scss */
+  /* line 349, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left img, .front-page-classic #row_3 .middle-center img, .front-page-classic #row_3 .middle-right img {
     display: flex;
     float: left;
     width: 42%;
   }
-  /* line 352, ../sass/custom/_frontpage.scss */
+  /* line 354, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left h2, .front-page-classic #row_3 .middle-center h2, .front-page-classic #row_3 .middle-right h2 {
     display: flex;
     padding-left: 20px;
   }
-  /* line 357, ../sass/custom/_frontpage.scss */
+  /* line 359, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left p, .front-page-classic #row_3 .middle-center p, .front-page-classic #row_3 .middle-right p {
     padding-left: 20px;
     display: flex;
   }
-  /* line 363, ../sass/custom/_frontpage.scss */
+  /* line 365, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 366, ../sass/custom/_frontpage.scss */
+  /* line 368, ../sass/custom/_frontpage.scss */
   .front-page-classic > div:not(:first-child) {
     padding-left: 24px;
   }
-  /* line 369, ../sass/custom/_frontpage.scss */
+  /* line 371, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout {
     margin-top: 10px;
   }
 }
 @media (min-width: 769px) and (max-width: 1050px) {
-  /* line 379, ../sass/custom/_frontpage.scss */
+  /* line 381, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 350px;
     margin-top: -1px;
   }
-  /* line 382, ../sass/custom/_frontpage.scss */
+  /* line 384, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 350px;
   }
-  /* line 385, ../sass/custom/_frontpage.scss */
+  /* line 387, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 350px !important;
   }
-  /* line 390, ../sass/custom/_frontpage.scss */
+  /* line 392, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h2 {
     font-size: 30px;
   }
-  /* line 393, ../sass/custom/_frontpage.scss */
+  /* line 395, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h1 {
     font-size: 48px;
   }
-  /* line 396, ../sass/custom/_frontpage.scss */
+  /* line 398, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper a {
     margin-top: 5px;
     font-size: 18px;
   }
-  /* line 403, ../sass/custom/_frontpage.scss */
+  /* line 405, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_text_wrapper {
     position: relative;
     top: -14px;
     min-width: 768px;
     max-width: 1050px;
   }
-  /* line 410, ../sass/custom/_frontpage.scss */
+  /* line 412, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows {
     width: 100px;
     position: absolute;
@@ -14155,61 +14161,61 @@ article.news .news_date {
     bottom: 0px;
     height: 60px;
   }
-  /* line 418, ../sass/custom/_frontpage.scss */
+  /* line 420, ../sass/custom/_frontpage.scss */
   .front-page-classic .first-content.col-md-8 {
     width: 100%;
   }
-  /* line 421, ../sass/custom/_frontpage.scss */
+  /* line 423, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 {
     width: 100%;
     margin-left: -15px;
     padding: 0px;
   }
-  /* line 426, ../sass/custom/_frontpage.scss */
+  /* line 428, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 .block-region-ctas {
     padding: 50px 0px 30px 30px;
   }
-  /* line 433, ../sass/custom/_frontpage.scss */
+  /* line 435, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
     width: 33%;
     display: flex;
     float: left;
   }
-  /* line 440, ../sass/custom/_frontpage.scss */
+  /* line 442, ../sass/custom/_frontpage.scss */
   .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
     width: 33%;
     display: flex;
     float: left;
   }
-  /* line 447, ../sass/custom/_frontpage.scss */
+  /* line 449, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout.col-md-3 {
     margin-top: -50px;
   }
 }
 @media (min-width: 1051px) and (max-width: 1300px) {
-  /* line 454, ../sass/custom/_frontpage.scss */
+  /* line 456, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 430px;
   }
-  /* line 456, ../sass/custom/_frontpage.scss */
+  /* line 458, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 430px;
   }
-  /* line 459, ../sass/custom/_frontpage.scss */
+  /* line 461, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 430px !important;
   }
 }
 @media (min-width: 1300px) {
-  /* line 471, ../sass/custom/_frontpage.scss */
+  /* line 473, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 515px;
   }
-  /* line 473, ../sass/custom/_frontpage.scss */
+  /* line 475, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 515px;
   }
-  /* line 476, ../sass/custom/_frontpage.scss */
+  /* line 478, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 515px !important;
     object-fit: cover;

--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -13843,89 +13843,89 @@ article.news .news_date {
   }
 }
 @media all and (min-width: 769px) {
-  /* line 111, ../sass/custom/_frontpage.scss */
+  /* line 102, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper img {
     max-width: 386px;
   }
 }
 @media all and (max-width: 480px) {
-  /* line 116, ../sass/custom/_frontpage.scss */
+  /* line 107, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image {
     width: 460px;
   }
 }
-/* line 120, ../sass/custom/_frontpage.scss */
+/* line 111, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
   object-fit: cover;
 }
 @media all and (max-width: 480px) {
-  /* line 120, ../sass/custom/_frontpage.scss */
+  /* line 111, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 92vw;
     height: 41vw;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 120, ../sass/custom/_frontpage.scss */
+  /* line 111, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 38vw;
     height: 17vw;
   }
 }
 @media all and (min-width: 769px) {
-  /* line 120, ../sass/custom/_frontpage.scss */
+  /* line 111, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 30vw;
     height: 180px;
   }
 }
-/* line 140, ../sass/custom/_frontpage.scss */
+/* line 130, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
   padding: 10px 0;
   margin-right: 30px;
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 140, ../sass/custom/_frontpage.scss */
+  /* line 130, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
     margin-left: 40px;
     width: 49vw;
     padding-right: 20px;
   }
 }
-/* line 158, ../sass/custom/_frontpage.scss */
+/* line 145, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link {
   margin-bottom: 10px;
 }
-/* line 160, ../sass/custom/_frontpage.scss */
+/* line 147, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
   text-decoration: none;
   text-transform: none;
   line-height: 1.0em;
 }
 @media all and (min-width: 1051px) {
-  /* line 160, ../sass/custom/_frontpage.scss */
+  /* line 147, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
     margin-top: 18px;
   }
 }
-/* line 171, ../sass/custom/_frontpage.scss */
+/* line 158, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a {
   text-decoration: none;
   text-transform: none;
 }
-/* line 175, ../sass/custom/_frontpage.scss */
+/* line 162, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a:hover li {
   color: #002E6D;
 }
-/* line 184, ../sass/custom/_frontpage.scss */
+/* line 171, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_body {
   color: #555;
 }
-/* line 187, ../sass/custom/_frontpage.scss */
+/* line 174, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links {
   display: flex;
 }
-/* line 190, ../sass/custom/_frontpage.scss */
+/* line 177, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a {
   font-family: "Open Sans Condensed", sans-serif;
   font-weight: 700;
@@ -13933,7 +13933,7 @@ article.news .news_date {
   text-transform: uppercase;
   text-decoration: none;
 }
-/* line 196, ../sass/custom/_frontpage.scss */
+/* line 183, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li {
   background-image: url(../images/png/orange-arrow.png);
   background-position: 100%;
@@ -13943,144 +13943,144 @@ article.news .news_date {
   margin-top: 10px;
   display: inline-flex;
 }
-/* line 204, ../sass/custom/_frontpage.scss */
+/* line 191, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li:hover {
   color: #002E6D;
   background-image: url(../images/png/dkblue-arrow.png);
 }
 
 @media (max-width: 480px) {
-  /* line 224, ../sass/custom/_frontpage.scss */
+  /* line 211, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-top {
     margin-top: -32px;
   }
-  /* line 228, ../sass/custom/_frontpage.scss */
+  /* line 215, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper {
     height: 100%;
   }
-  /* line 230, ../sass/custom/_frontpage.scss */
+  /* line 217, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_image_wrapper {
     height: 155px;
     overflow: hidden;
   }
-  /* line 234, ../sass/custom/_frontpage.scss */
+  /* line 221, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper {
     background-color: #616161 !important;
     padding-left: 20px;
   }
-  /* line 237, ../sass/custom/_frontpage.scss */
+  /* line 224, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text {
     position: relative;
     padding-left: 40px;
   }
-  /* line 240, ../sass/custom/_frontpage.scss */
+  /* line 227, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-top: 0;
     font-weight: 400;
   }
-  /* line 244, ../sass/custom/_frontpage.scss */
+  /* line 231, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text a {
     font-weight: 400;
     font-weight: normal;
   }
-  /* line 251, ../sass/custom/_frontpage.scss */
+  /* line 238, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows, .front-page-classic .slick-arrow {
     display: none !important;
   }
-  /* line 257, ../sass/custom/_frontpage.scss */
+  /* line 244, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 261, ../sass/custom/_frontpage.scss */
+  /* line 248, ../sass/custom/_frontpage.scss */
   .front-page-classic > div {
     padding-left: 0 !important;
   }
 }
 @media (min-width: 481px) and (max-width: 768px) {
-  /* line 270, ../sass/custom/_frontpage.scss */
+  /* line 257, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 256px;
   }
-  /* line 272, ../sass/custom/_frontpage.scss */
+  /* line 259, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 256px;
   }
-  /* line 274, ../sass/custom/_frontpage.scss */
+  /* line 261, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper {
     height: 256px;
     overflow: hidden;
   }
-  /* line 277, ../sass/custom/_frontpage.scss */
+  /* line 264, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 256px !important;
   }
-  /* line 281, ../sass/custom/_frontpage.scss */
+  /* line 268, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper {
     max-width: 768px;
     min-width: 480px;
   }
-  /* line 285, ../sass/custom/_frontpage.scss */
+  /* line 272, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text {
     padding-left: 40px;
   }
-  /* line 287, ../sass/custom/_frontpage.scss */
+  /* line 274, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-bottom: 0;
   }
-  /* line 298, ../sass/custom/_frontpage.scss */
+  /* line 285, ../sass/custom/_frontpage.scss */
   .front-page-classic .featured_content_image img {
     display: flex;
     float: left;
     width: 42%;
   }
-  /* line 323, ../sass/custom/_frontpage.scss */
+  /* line 292, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 326, ../sass/custom/_frontpage.scss */
+  /* line 295, ../sass/custom/_frontpage.scss */
   .front-page-classic > div:not(:first-child) {
     padding-left: 24px;
   }
-  /* line 329, ../sass/custom/_frontpage.scss */
+  /* line 298, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout {
     margin-top: 10px;
   }
 }
 @media (min-width: 769px) and (max-width: 1050px) {
-  /* line 339, ../sass/custom/_frontpage.scss */
+  /* line 308, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 350px;
     margin-top: -1px;
   }
-  /* line 342, ../sass/custom/_frontpage.scss */
+  /* line 311, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 350px;
   }
-  /* line 345, ../sass/custom/_frontpage.scss */
+  /* line 314, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 350px !important;
   }
-  /* line 350, ../sass/custom/_frontpage.scss */
+  /* line 319, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h2 {
     font-size: 30px;
   }
-  /* line 353, ../sass/custom/_frontpage.scss */
+  /* line 322, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h1 {
     font-size: 48px;
   }
-  /* line 356, ../sass/custom/_frontpage.scss */
+  /* line 325, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper a {
     margin-top: 5px;
     font-size: 18px;
   }
-  /* line 363, ../sass/custom/_frontpage.scss */
+  /* line 332, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_text_wrapper {
     position: relative;
     top: -14px;
     min-width: 768px;
     max-width: 1050px;
   }
-  /* line 370, ../sass/custom/_frontpage.scss */
+  /* line 339, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows {
     width: 100px;
     position: absolute;
@@ -14088,49 +14088,49 @@ article.news .news_date {
     bottom: 0px;
     height: 60px;
   }
-  /* line 378, ../sass/custom/_frontpage.scss */
+  /* line 347, ../sass/custom/_frontpage.scss */
   .front-page-classic .first-content.col-md-8 {
     width: 100%;
   }
-  /* line 381, ../sass/custom/_frontpage.scss */
+  /* line 350, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 {
     width: 100%;
     margin-left: -15px;
     padding: 0px;
   }
-  /* line 386, ../sass/custom/_frontpage.scss */
+  /* line 355, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 .block-region-ctas {
     padding: 50px 0px 30px 30px;
   }
-  /* line 400, ../sass/custom/_frontpage.scss */
+  /* line 360, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout.col-md-3 {
     margin-top: -50px;
   }
 }
 @media (min-width: 1051px) and (max-width: 1300px) {
-  /* line 407, ../sass/custom/_frontpage.scss */
+  /* line 367, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 430px;
   }
-  /* line 409, ../sass/custom/_frontpage.scss */
+  /* line 369, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 430px;
   }
-  /* line 412, ../sass/custom/_frontpage.scss */
+  /* line 372, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 430px !important;
   }
 }
 @media (min-width: 1300px) {
-  /* line 424, ../sass/custom/_frontpage.scss */
+  /* line 384, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 515px;
   }
-  /* line 426, ../sass/custom/_frontpage.scss */
+  /* line 386, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 515px;
   }
-  /* line 429, ../sass/custom/_frontpage.scss */
+  /* line 389, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 515px !important;
     object-fit: cover;

--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -13735,7 +13735,7 @@ article.news .news_date {
 }
 
 /* line 9, ../sass/custom/_frontpage.scss */
-.front-page-classic #row_3 .middle-left h2, .front-page-classic #row_3 .middle-center h2, .front-page-classic #row_3 .middle-right h2, .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li, .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a {
+.front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li, .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a {
   color: #FFA300;
   font-size: 40px;
   font-weight: 600;
@@ -13767,38 +13767,21 @@ article.news .news_date {
 .front-page-classic > div:nth-child(3n), .front-page-classic #row_5 {
   margin-bottom: 40px;
 }
-/* line 45, ../sass/custom/_frontpage.scss */
-.front-page-classic #row_3 .middle-left p, .front-page-classic #row_3 .middle-center p, .front-page-classic #row_3 .middle-right p {
-  font-size: 18px;
-  margin-bottom: 10px;
-}
-/* line 49, ../sass/custom/_frontpage.scss */
-.front-page-classic #row_3 .middle-left a, .front-page-classic #row_3 .middle-center a, .front-page-classic #row_3 .middle-right a {
-  font-family: "Open Sans Condensed", sans-serif;
-  font-weight: 700;
-  color: #FFA300;
-  background-image: url(../images/png/orange-arrow.png);
-  background-position: 100%;
-  background-repeat: no-repeat;
-  padding: 0px 20px 0px 0px;
-  text-transform: uppercase;
-  text-decoration: none;
-}
-/* line 64, ../sass/custom/_frontpage.scss */
+/* line 39, ../sass/custom/_frontpage.scss */
 .front-page-classic .main .col-md-12 .center_column .front-page-classic .slide {
   height: 515px;
 }
-/* line 69, ../sass/custom/_frontpage.scss */
+/* line 44, ../sass/custom/_frontpage.scss */
 .front-page-classic .first-content h3 {
   font-weight: 500;
   color: #0054A6;
   font-size: 28px;
 }
-/* line 74, ../sass/custom/_frontpage.scss */
+/* line 49, ../sass/custom/_frontpage.scss */
 .front-page-classic .first-content p {
   font-size: 18px;
 }
-/* line 77, ../sass/custom/_frontpage.scss */
+/* line 52, ../sass/custom/_frontpage.scss */
 .front-page-classic .first-content a {
   font-size: 20px;
   background-color: #0054A6;
@@ -13812,148 +13795,137 @@ article.news .news_date {
   text-decoration: none;
   text-transform: uppercase;
 }
-/* line 90, ../sass/custom/_frontpage.scss */
+/* line 65, ../sass/custom/_frontpage.scss */
 .front-page-classic .first-content a:hover {
   text-decoration: none;
   color: #FFF;
   background-color: #002E6D;
   text-transform: uppercase;
 }
-/* line 98, ../sass/custom/_frontpage.scss */
+/* line 73, ../sass/custom/_frontpage.scss */
 .front-page-classic .bottom_callout {
   margin-top: -50px;
 }
-/* line 105, ../sass/custom/_frontpage.scss */
+@media all and (min-width: 769px) and (max-width: 1050px) {
+  /* line 77, ../sass/custom/_frontpage.scss */
+  .front-page-classic .desktop_vertical .field--items {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+/* line 83, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
   background-color: transparent;
   margin-bottom: 20px;
 }
 @media all and (max-width: 480px) {
-  /* line 105, ../sass/custom/_frontpage.scss */
+  /* line 83, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
     margin-bottom: 40px;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 105, ../sass/custom/_frontpage.scss */
+  /* line 83, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
     margin-bottom: 40px;
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 105, ../sass/custom/_frontpage.scss */
+  /* line 83, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
-    display: flex;
-    flex-direction: row;
-    width: 95% !important;
-    margin-bottom: 30px;
+    max-width: 388px;
   }
 }
-@media all and (min-width: 1051px) {
-  /* line 105, ../sass/custom/_frontpage.scss */
+@media all and (min-width: 769px) {
+  /* line 83, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
-    max-width: 600px;
-    min-width: 336px;
+    flex-flow: column nowrap;
+    height: 100%;
   }
 }
-@media all and (min-width: 1051px) {
-  /* line 129, ../sass/custom/_frontpage.scss */
+@media all and (min-width: 769px) {
+  /* line 111, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper img {
     max-width: 386px;
   }
 }
 @media all and (max-width: 480px) {
-  /* line 134, ../sass/custom/_frontpage.scss */
+  /* line 116, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image {
     width: 460px;
   }
 }
-/* line 138, ../sass/custom/_frontpage.scss */
+/* line 120, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
   object-fit: cover;
 }
 @media all and (max-width: 480px) {
-  /* line 138, ../sass/custom/_frontpage.scss */
+  /* line 120, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 92vw;
     height: 41vw;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 138, ../sass/custom/_frontpage.scss */
+  /* line 120, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 38vw;
     height: 17vw;
   }
 }
-@media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 138, ../sass/custom/_frontpage.scss */
-  .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
-    max-width: 282px;
-    height: 128px;
-  }
-}
-@media all and (min-width: 1051px) {
-  /* line 138, ../sass/custom/_frontpage.scss */
+@media all and (min-width: 769px) {
+  /* line 120, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_image img {
     width: 30vw;
     height: 180px;
   }
 }
-/* line 158, ../sass/custom/_frontpage.scss */
+/* line 140, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
   padding: 10px 0;
   margin-right: 30px;
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
-  /* line 158, ../sass/custom/_frontpage.scss */
+  /* line 140, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
     margin-left: 40px;
     width: 49vw;
     padding-right: 20px;
   }
 }
-@media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 158, ../sass/custom/_frontpage.scss */
-  .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content {
-    margin-left: 80px;
-    margin-top: -15px;
-  }
-}
-/* line 176, ../sass/custom/_frontpage.scss */
+/* line 158, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link {
   margin-bottom: 10px;
 }
-/* line 178, ../sass/custom/_frontpage.scss */
+/* line 160, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
   text-decoration: none;
   text-transform: none;
   line-height: 1.0em;
 }
 @media all and (min-width: 1051px) {
-  /* line 178, ../sass/custom/_frontpage.scss */
+  /* line 160, ../sass/custom/_frontpage.scss */
   .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link li {
     margin-top: 18px;
   }
 }
-/* line 189, ../sass/custom/_frontpage.scss */
+/* line 171, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a {
   text-decoration: none;
   text-transform: none;
 }
-/* line 193, ../sass/custom/_frontpage.scss */
+/* line 175, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_link .links_wrapper a:hover li {
   color: #002E6D;
 }
-/* line 202, ../sass/custom/_frontpage.scss */
+/* line 184, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_body {
   color: #555;
 }
-/* line 205, ../sass/custom/_frontpage.scss */
+/* line 187, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links {
   display: flex;
 }
-/* line 208, ../sass/custom/_frontpage.scss */
+/* line 190, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a {
   font-family: "Open Sans Condensed", sans-serif;
   font-weight: 700;
@@ -13961,7 +13933,7 @@ article.news .news_date {
   text-transform: uppercase;
   text-decoration: none;
 }
-/* line 214, ../sass/custom/_frontpage.scss */
+/* line 196, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li {
   background-image: url(../images/png/orange-arrow.png);
   background-position: 100%;
@@ -13971,189 +13943,144 @@ article.news .news_date {
   margin-top: 10px;
   display: inline-flex;
 }
-/* line 222, ../sass/custom/_frontpage.scss */
+/* line 204, ../sass/custom/_frontpage.scss */
 .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper .featured_content_content .featured_content_additional_links .links_wrapper a li:hover {
   color: #002E6D;
   background-image: url(../images/png/dkblue-arrow.png);
 }
 
 @media (max-width: 480px) {
-  /* line 242, ../sass/custom/_frontpage.scss */
+  /* line 224, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-top {
     margin-top: -32px;
   }
-  /* line 246, ../sass/custom/_frontpage.scss */
+  /* line 228, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper {
     height: 100%;
   }
-  /* line 248, ../sass/custom/_frontpage.scss */
+  /* line 230, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_image_wrapper {
     height: 155px;
     overflow: hidden;
   }
-  /* line 252, ../sass/custom/_frontpage.scss */
+  /* line 234, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper {
     background-color: #616161 !important;
     padding-left: 20px;
   }
-  /* line 255, ../sass/custom/_frontpage.scss */
+  /* line 237, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text {
     position: relative;
     padding-left: 40px;
   }
-  /* line 258, ../sass/custom/_frontpage.scss */
+  /* line 240, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-top: 0;
     font-weight: 400;
   }
-  /* line 262, ../sass/custom/_frontpage.scss */
+  /* line 244, ../sass/custom/_frontpage.scss */
   .front-page-classic .slide_wrapper .slide_text_wrapper .slide_text a {
     font-weight: 400;
     font-weight: normal;
   }
-  /* line 269, ../sass/custom/_frontpage.scss */
+  /* line 251, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows, .front-page-classic .slick-arrow {
     display: none !important;
   }
-  /* line 275, ../sass/custom/_frontpage.scss */
+  /* line 257, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 280, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
-    margin-bottom: 25px;
-  }
-  /* line 282, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left img, .front-page-classic #row_3 .middle-center img, .front-page-classic #row_3 .middle-right img {
-    width: 99%;
-  }
-  /* line 286, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left p, .front-page-classic #row_3 .middle-center p, .front-page-classic #row_3 .middle-right p {
-    font-size: 18px;
-    margin-bottom: 10px;
-  }
-  /* line 290, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left a, .front-page-classic #row_3 .middle-center a, .front-page-classic #row_3 .middle-right a {
-    font-family: "Open Sans Condensed", sans-serif;
-    font-weight: 700;
-    color: #FFA300;
-    background-image: url(../images/png/orange-arrow.png);
-    background-position: 100%;
-    background-repeat: no-repeat;
-    padding: 0px 20px 0px 0px;
-    text-transform: uppercase;
-    text-decoration: none;
-  }
-  /* line 303, ../sass/custom/_frontpage.scss */
+  /* line 261, ../sass/custom/_frontpage.scss */
   .front-page-classic > div {
     padding-left: 0 !important;
   }
 }
 @media (min-width: 481px) and (max-width: 768px) {
-  /* line 312, ../sass/custom/_frontpage.scss */
+  /* line 270, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 256px;
   }
-  /* line 314, ../sass/custom/_frontpage.scss */
+  /* line 272, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 256px;
   }
-  /* line 316, ../sass/custom/_frontpage.scss */
+  /* line 274, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper {
     height: 256px;
     overflow: hidden;
   }
-  /* line 319, ../sass/custom/_frontpage.scss */
+  /* line 277, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 256px !important;
   }
-  /* line 323, ../sass/custom/_frontpage.scss */
+  /* line 281, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper {
     max-width: 768px;
     min-width: 480px;
   }
-  /* line 327, ../sass/custom/_frontpage.scss */
+  /* line 285, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text {
     padding-left: 40px;
   }
-  /* line 329, ../sass/custom/_frontpage.scss */
+  /* line 287, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper .slide_text h2 {
     margin-bottom: 0;
   }
-  /* line 340, ../sass/custom/_frontpage.scss */
+  /* line 298, ../sass/custom/_frontpage.scss */
   .front-page-classic .featured_content_image img {
     display: flex;
     float: left;
     width: 42%;
   }
-  /* line 347, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
-    margin-bottom: 20px;
-  }
-  /* line 349, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left img, .front-page-classic #row_3 .middle-center img, .front-page-classic #row_3 .middle-right img {
-    display: flex;
-    float: left;
-    width: 42%;
-  }
-  /* line 354, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left h2, .front-page-classic #row_3 .middle-center h2, .front-page-classic #row_3 .middle-right h2 {
-    display: flex;
-    padding-left: 20px;
-  }
-  /* line 359, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left p, .front-page-classic #row_3 .middle-center p, .front-page-classic #row_3 .middle-right p {
-    padding-left: 20px;
-    display: flex;
-  }
-  /* line 365, ../sass/custom/_frontpage.scss */
+  /* line 323, ../sass/custom/_frontpage.scss */
   .front-page-classic .block-region-ctas {
     padding: 50px 0 40px 0;
   }
-  /* line 368, ../sass/custom/_frontpage.scss */
+  /* line 326, ../sass/custom/_frontpage.scss */
   .front-page-classic > div:not(:first-child) {
     padding-left: 24px;
   }
-  /* line 371, ../sass/custom/_frontpage.scss */
+  /* line 329, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout {
     margin-top: 10px;
   }
 }
 @media (min-width: 769px) and (max-width: 1050px) {
-  /* line 381, ../sass/custom/_frontpage.scss */
+  /* line 339, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 350px;
     margin-top: -1px;
   }
-  /* line 384, ../sass/custom/_frontpage.scss */
+  /* line 342, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 350px;
   }
-  /* line 387, ../sass/custom/_frontpage.scss */
+  /* line 345, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 350px !important;
   }
-  /* line 392, ../sass/custom/_frontpage.scss */
+  /* line 350, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h2 {
     font-size: 30px;
   }
-  /* line 395, ../sass/custom/_frontpage.scss */
+  /* line 353, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper h1 {
     font-size: 48px;
   }
-  /* line 398, ../sass/custom/_frontpage.scss */
+  /* line 356, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_text_wrapper a {
     margin-top: 5px;
     font-size: 18px;
   }
-  /* line 405, ../sass/custom/_frontpage.scss */
+  /* line 363, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_text_wrapper {
     position: relative;
     top: -14px;
     min-width: 768px;
     max-width: 1050px;
   }
-  /* line 412, ../sass/custom/_frontpage.scss */
+  /* line 370, ../sass/custom/_frontpage.scss */
   .front-page-classic .new-arrows {
     width: 100px;
     position: absolute;
@@ -14161,61 +14088,49 @@ article.news .news_date {
     bottom: 0px;
     height: 60px;
   }
-  /* line 420, ../sass/custom/_frontpage.scss */
+  /* line 378, ../sass/custom/_frontpage.scss */
   .front-page-classic .first-content.col-md-8 {
     width: 100%;
   }
-  /* line 423, ../sass/custom/_frontpage.scss */
+  /* line 381, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 {
     width: 100%;
     margin-left: -15px;
     padding: 0px;
   }
-  /* line 428, ../sass/custom/_frontpage.scss */
+  /* line 386, ../sass/custom/_frontpage.scss */
   .front-page-classic .calls-to-action.col-md-4 .block-region-ctas {
     padding: 50px 0px 30px 30px;
   }
-  /* line 435, ../sass/custom/_frontpage.scss */
-  .front-page-classic .desktop_vertical .field--items .featured_content_item_wrapper {
-    width: 33%;
-    display: flex;
-    float: left;
-  }
-  /* line 442, ../sass/custom/_frontpage.scss */
-  .front-page-classic #row_3 .middle-left, .front-page-classic #row_3 .middle-center, .front-page-classic #row_3 .middle-right {
-    width: 33%;
-    display: flex;
-    float: left;
-  }
-  /* line 449, ../sass/custom/_frontpage.scss */
+  /* line 400, ../sass/custom/_frontpage.scss */
   .front-page-classic .bottom_callout.col-md-3 {
     margin-top: -50px;
   }
 }
 @media (min-width: 1051px) and (max-width: 1300px) {
-  /* line 456, ../sass/custom/_frontpage.scss */
+  /* line 407, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 430px;
   }
-  /* line 458, ../sass/custom/_frontpage.scss */
+  /* line 409, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 430px;
   }
-  /* line 461, ../sass/custom/_frontpage.scss */
+  /* line 412, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 430px !important;
   }
 }
 @media (min-width: 1300px) {
-  /* line 473, ../sass/custom/_frontpage.scss */
+  /* line 424, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper {
     height: 515px;
   }
-  /* line 475, ../sass/custom/_frontpage.scss */
+  /* line 426, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper {
     height: 515px;
   }
-  /* line 478, ../sass/custom/_frontpage.scss */
+  /* line 429, ../sass/custom/_frontpage.scss */
   .front-page-classic .slideshow_wrapper .slide_wrapper .slide_image_wrapper img {
     height: 515px !important;
     object-fit: cover;

--- a/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
@@ -107,10 +107,10 @@
             // max-width: 600px;
             margin-bottom: 20px;
             @include respond-to(null, mobile-max){
-                margin-bottom: 80px;
+                margin-bottom: 40px;
             }
             @include respond-to(tablet-min, tablet-max){
-                margin-bottom: 80px;
+                margin-bottom: 40px;
             }
             @include respond-to(lg-tablet-min, lg-tablet-max){
                 display:flex;
@@ -132,7 +132,9 @@
                 }
             } 
             .featured_content_image {
-               
+               @include respond-to(null, mobile-max){
+                   width:460px;
+               }
                 img {
                     object-fit: cover;
                     @include respond-to(null, mobile-max){

--- a/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
@@ -90,20 +90,11 @@
                 margin-bottom: 40px;
             }
             @include respond-to(lg-tablet-min, lg-tablet-max){
-                // display:flex;
-                // flex-direction: row;
-                // width:95% !important;
-                // margin-bottom: 30px;
-                // flex-wrap: wrap;
                 max-width: 388px;
                
                 
             }  
             @include respond-to(lg-tablet-min, null){
-                // max-width: 340px;
-                //--- max-width: 600px;
-                // min-width: 336px;
-                
                 flex-flow: column nowrap;
                 height: 100%;
 
@@ -127,10 +118,9 @@
                         width: 38vw;
                         height: 17vw;
                     }
-                    // @include respond-to(lg-tablet-min, lg-tablet-max){
-                    //     max-width: 282px;
-                    //     height: 128px;
-                    // }
+                    @include respond-to(lg-tablet-min, lg-tablet-max){
+                        
+                    }
                     @include respond-to(lg-tablet-min, null){
                         width: 30vw;
                         height: 180px;
@@ -140,19 +130,16 @@
             .featured_content_content{
                 padding: 10px 0;
                 margin-right: 30px;
-                // width: 90vw;
                 @include respond-to(tablet-min, tablet-max){
                     margin-left: 40px;
                     width: 49vw;
                     padding-right: 20px;
                 }
                 @include respond-to( lg-tablet-min, lg-tablet-max){
-                    // margin-left: 80px;
-                    // margin-top: -15px;
+                    
                     
                 }
                 @include respond-to(desktop-min, null){
-                    // max-width: 395px;
                 }
 
                 .featured_content_link{
@@ -301,25 +288,7 @@
                 width: 42%;
             }
         }
-        // #row_3{
-        //     .middle-left, .middle-center, .middle-right{
-        //         margin-bottom: 20px;
-        //         img{
-        //             display: flex;
-        //             float: left;
-        //             width: 42%;
-        //         }
-        //         h2{
-        //             display: flex;
-        //             padding-left: 20px;
-        //         }
-                
-        //         p{
-        //             padding-left: 20px;
-        //             display: flex;
-        //         }
-        //     }
-        // }      
+             
         .block-region-ctas {
             padding: 50px 0 40px 0;
         }
@@ -387,15 +356,6 @@
                 padding: 50px 0px 30px 30px;
             }
         }
-        // ----FEATURED CONTENT
-        // .desktop_vertical .field--items{
-           
-        //     .featured_content_item_wrapper{
-        //         width: 33%;
-        //         display: flex;
-        //         float: left;
-        //     }
-        // }
 
         .bottom_callout.col-md-3 {
             margin-top: -50px;

--- a/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_frontpage.scss
@@ -35,31 +35,6 @@
     > div:nth-child(3n), #row_5 {
         margin-bottom: 40px;
     }
-// old row 3 CAN REMOVE EVENTUALLY
-    #row_3{
-        .middle-left, .middle-center, .middle-right{
-            
-            h2{
-                @extend %orange-h2;
-            }
-            p{
-                font-size: $pLargerFontSize;
-                margin-bottom: 10px;
-            }
-            a{
-                font-family: $condensedFont;
-                font-weight: $bold;
-                color: $orange;
-                background-image: url(../images/png/orange-arrow.png);
-                background-position: 100%;
-                background-repeat: no-repeat;
-                padding: 0px 20px 0px 0px;
-                text-transform: uppercase;
-                text-decoration: none;
-            }
-        }
-    }
-// old row 3 CAN REMOVE EVENTUALLY
 
     .main .col-md-12 .center_column .front-page-classic .slide {
         height: 515px;
@@ -101,10 +76,12 @@
 //  FEATURED CONTENT AREA
     .desktop_vertical .field--items { 
         // width: 393px;
+        @include respond-to(lg-tablet-min, lg-tablet-max){
+            grid-template-columns: 1fr 1fr 1fr;
+        }
         
         .featured_content_item_wrapper{
             background-color: transparent;
-            // max-width: 600px;
             margin-bottom: 20px;
             @include respond-to(null, mobile-max){
                 margin-bottom: 40px;
@@ -113,21 +90,26 @@
                 margin-bottom: 40px;
             }
             @include respond-to(lg-tablet-min, lg-tablet-max){
-                display:flex;
-                flex-direction: row;
-                width:95% !important;
-                margin-bottom: 30px;
+                // display:flex;
+                // flex-direction: row;
+                // width:95% !important;
+                // margin-bottom: 30px;
                 // flex-wrap: wrap;
+                max-width: 388px;
+               
                 
             }  
-            @include respond-to(desktop-min, null){
+            @include respond-to(lg-tablet-min, null){
                 // max-width: 340px;
-                max-width: 600px;
-                min-width: 336px;
+                //--- max-width: 600px;
+                // min-width: 336px;
                 
+                flex-flow: column nowrap;
+                height: 100%;
+
             } 
             img{
-                @include respond-to(desktop-min, null){
+                @include respond-to(lg-tablet-min, null){
                     max-width: 386px;
                 }
             } 
@@ -145,11 +127,11 @@
                         width: 38vw;
                         height: 17vw;
                     }
-                    @include respond-to(lg-tablet-min, lg-tablet-max){
-                        max-width: 282px;
-                        height: 128px;
-                    }
-                    @include respond-to(desktop-min, null){
+                    // @include respond-to(lg-tablet-min, lg-tablet-max){
+                    //     max-width: 282px;
+                    //     height: 128px;
+                    // }
+                    @include respond-to(lg-tablet-min, null){
                         width: 30vw;
                         height: 180px;
                     }
@@ -165,8 +147,8 @@
                     padding-right: 20px;
                 }
                 @include respond-to( lg-tablet-min, lg-tablet-max){
-                    margin-left: 80px;
-                    margin-top: -15px;
+                    // margin-left: 80px;
+                    // margin-top: -15px;
                     
                 }
                 @include respond-to(desktop-min, null){
@@ -276,30 +258,6 @@
             padding: 50px 0 40px 0;
         }
         
-        #row_3{
-            .middle-left, .middle-center, .middle-right{
-                margin-bottom: 25px;
-                img {
-                    width: 99%;
-                }
-                
-                p {
-                    font-size: $pLargerFontSize;
-                    margin-bottom: 10px;
-                }
-                a {
-                    font-family: $condensedFont;
-                    font-weight: $bold;
-                    color: $orange;
-                    background-image: url(../images/png/orange-arrow.png);
-                    background-position: 100%;
-                    background-repeat: no-repeat;
-                    padding: 0px 20px 0px 0px;
-                    text-transform: uppercase;
-                    text-decoration: none;
-                }
-            }
-        }
         > div{
             padding-left: 0 !important;
         }
@@ -343,25 +301,25 @@
                 width: 42%;
             }
         }
-        #row_3{
-            .middle-left, .middle-center, .middle-right{
-                margin-bottom: 20px;
-                img{
-                    display: flex;
-                    float: left;
-                    width: 42%;
-                }
-                h2{
-                    display: flex;
-                    padding-left: 20px;
-                }
+        // #row_3{
+        //     .middle-left, .middle-center, .middle-right{
+        //         margin-bottom: 20px;
+        //         img{
+        //             display: flex;
+        //             float: left;
+        //             width: 42%;
+        //         }
+        //         h2{
+        //             display: flex;
+        //             padding-left: 20px;
+        //         }
                 
-                p{
-                    padding-left: 20px;
-                    display: flex;
-                }
-            }
-        }      
+        //         p{
+        //             padding-left: 20px;
+        //             display: flex;
+        //         }
+        //     }
+        // }      
         .block-region-ctas {
             padding: 50px 0 40px 0;
         }
@@ -429,22 +387,15 @@
                 padding: 50px 0px 30px 30px;
             }
         }
-        
-        .desktop_vertical .field--items{
+        // ----FEATURED CONTENT
+        // .desktop_vertical .field--items{
            
-            .featured_content_item_wrapper{
-                width: 33%;
-                display: flex;
-                float: left;
-            }
-        }
-        #row_3{
-            .middle-left, .middle-center, .middle-right{
-                width: 33%;
-                display: flex;
-                float: left;
-            }
-        }
+        //     .featured_content_item_wrapper{
+        //         width: 33%;
+        //         display: flex;
+        //         float: left;
+        //     }
+        // }
 
         .bottom_callout.col-md-3 {
             margin-top: -50px;


### PR DESCRIPTION
# Description

Fixes to the front page noted from testing. 
- Tablet 1024 should emulate desktop layout with 3 across instead of stacked.
- Tablet 768 should tighten up the vertical spacing between each featured content.
- Mobile 480 images should be full width of content above it, right now it's about 85%.
- Mobile 480 vertical space between each featured content can be tightened up.



## Steps to Test or Reproduce

pull branch down
vagrant up
vagrant ssh
visit local.creighton.edu
view front page with featured content group on the front page
