### PR TITLE
Adds a block display for the news view

### DIFF
--- a/config/default/views.view.cu_news.yml
+++ b/config/default/views.view.cu_news.yml
@@ -1117,6 +1117,33 @@ display:
         - 'config:field.storage.node.field_links_link'
         - 'config:field.storage.node.field_links_open_in_new_window'
         - 'config:field.storage.node.field_new'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      defaults:
+        fields: true
+        title: false
+      title: 'Creighton News'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_content_page_headline'
+        - 'config:field.storage.node.field_content_page_image'
+        - 'config:field.storage.node.field_links_file_link_upload'
+        - 'config:field.storage.node.field_links_link'
+        - 'config:field.storage.node.field_links_open_in_new_window'
+        - 'config:field.storage.node.field_new'
   page_1:
     display_plugin: page
     id: page_1


### PR DESCRIPTION
# Description

CU News display now has a block that can be added to a panelized page, per https://www.wrike.com/open.htm?id=319705585
