### PR TITLE
Footer styling

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -10131,8 +10131,9 @@ footer .footer_wrapper .footer_contact_wrapper p a {
   text-decoration: none;
   font-weight: 600;
   color: #FFF;
+  white-space: nowrap;
 }
-/* line 209, ../sass/custom/_footer.scss */
+/* line 210, ../sass/custom/_footer.scss */
 footer .footer_wrapper .footer_contact_wrapper p a:hover {
   background-color: #0054A6;
   color: #FFF;

--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -10128,11 +10128,13 @@ footer .footer_wrapper .footer_contact_wrapper p {
 }
 /* line 204, ../sass/custom/_footer.scss */
 footer .footer_wrapper .footer_contact_wrapper p a {
+  text-decoration: none;
+  font-weight: 600;
   color: #FFF;
-  white-space: nowrap;
 }
-/* line 208, ../sass/custom/_footer.scss */
+/* line 209, ../sass/custom/_footer.scss */
 footer .footer_wrapper .footer_contact_wrapper p a:hover {
+  background-color: #0054A6;
   color: #FFF;
   text-decoration: underline;
 }

--- a/docroot/themes/custom/cu2017/sass/custom/_footer.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_footer.scss
@@ -201,14 +201,16 @@ footer {
 			p {
 				margin: 0 0 5px;
 
-				a {
+				a {	
+					text-decoration: none;
+					font-weight: $semiBold;
 					color: $white;
-					white-space: nowrap;
-
-					&:hover {
-						color: $white;
-						text-decoration: underline;
-					}
+				
+				&:hover {
+					background-color: $mediumBlue;
+					color: $white;
+					text-decoration: underline;
+				}
 				}
 			}
 		}

--- a/docroot/themes/custom/cu2017/sass/custom/_footer.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_footer.scss
@@ -205,6 +205,7 @@ footer {
 					text-decoration: none;
 					font-weight: $semiBold;
 					color: $white;
+					white-space: nowrap;
 				
 				&:hover {
 					background-color: $mediumBlue;


### PR DESCRIPTION
# Description

updates per testing the contact area of the footer's links should also be bold and underline only on hover

##reproduce
pull down branch
vagrant up
visit local.creighton.edu 
scroll to footer
verify the creighton.edu link is semi bold and underlines on hover