### PR TITLE
styling fixes to get transaction menu above search on mobile and expa…

### DIFF
--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -12630,13 +12630,13 @@ article figcaption {
 @media all and (max-width: 480px) {
   /* line 1, ../sass/custom/_megamenu.scss */
   .header_top_section_mega_menu {
-    top: 130px;
+    top: 165px;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
   /* line 1, ../sass/custom/_megamenu.scss */
   .header_top_section_mega_menu {
-    top: 130px;
+    top: 165px;
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {

--- a/docroot/themes/custom/cu2017/css/style.css
+++ b/docroot/themes/custom/cu2017/css/style.css
@@ -10162,14 +10162,20 @@ header .header_bg_wrapper {
   width: 100%;
   z-index: 6;
 }
+@media all and (max-width: 768px) {
+  /* line 14, ../sass/custom/_header.scss */
+  header .header_bg_wrapper {
+    margin-top: 40px;
+  }
+}
 @media all and (min-width: 769px) {
-  /* line 21, ../sass/custom/_header.scss */
+  /* line 24, ../sass/custom/_header.scss */
   header.header_opacity .header_bg_wrapper {
     background-color: rgba(0, 84, 166, 0.8);
     z-index: 6;
   }
 }
-/* line 29, ../sass/custom/_header.scss */
+/* line 32, ../sass/custom/_header.scss */
 header .header_inner_wrapper {
   display: flex;
   flex-direction: row;
@@ -10179,13 +10185,13 @@ header .header_inner_wrapper {
   width: 100%;
 }
 @media all and (min-width: 1051px) {
-  /* line 29, ../sass/custom/_header.scss */
+  /* line 32, ../sass/custom/_header.scss */
   header .header_inner_wrapper {
     height: 85px;
   }
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 29, ../sass/custom/_header.scss */
+  /* line 32, ../sass/custom/_header.scss */
   header .header_inner_wrapper {
     align-items: center;
     flex-direction: column;
@@ -10193,19 +10199,19 @@ header .header_inner_wrapper {
   }
 }
 @media all and (min-width: 320px) and (max-width: 768px) {
-  /* line 29, ../sass/custom/_header.scss */
+  /* line 32, ../sass/custom/_header.scss */
   header .header_inner_wrapper {
     height: 100px;
     padding: 0 20px;
   }
 }
 @media all and (max-width: 319px) {
-  /* line 29, ../sass/custom/_header.scss */
+  /* line 32, ../sass/custom/_header.scss */
   header .header_inner_wrapper {
     height: 130px;
   }
 }
-/* line 54, ../sass/custom/_header.scss */
+/* line 57, ../sass/custom/_header.scss */
 header .header_top_section {
   background-color: #002E6D;
   height: 35px;
@@ -10213,41 +10219,41 @@ header .header_top_section {
   text-align: center;
 }
 @media all and (max-width: 480px) {
-  /* line 54, ../sass/custom/_header.scss */
+  /* line 57, ../sass/custom/_header.scss */
   header .header_top_section {
-    background-color: white;
+    background-color: #019CDB;
   }
 }
 @media all and (min-width: 1051px) {
-  /* line 54, ../sass/custom/_header.scss */
+  /* line 57, ../sass/custom/_header.scss */
   header .header_top_section {
     display: flex;
   }
 }
-/* line 65, ../sass/custom/_header.scss */
+/* line 68, ../sass/custom/_header.scss */
 header .header_top_section .tt-menu {
   text-align: left;
 }
-/* line 70, ../sass/custom/_header.scss */
+/* line 73, ../sass/custom/_header.scss */
 header .header_top_section_wrapper {
   margin: auto;
   max-width: 1300px;
   width: 100%;
 }
 @media all and (max-width: 1050px) {
-  /* line 70, ../sass/custom/_header.scss */
+  /* line 73, ../sass/custom/_header.scss */
   header .header_top_section_wrapper {
     padding-right: 0;
   }
 }
-/* line 79, ../sass/custom/_header.scss */
+/* line 82, ../sass/custom/_header.scss */
 header .header_top_section_wrapper .header_top_section_wrapper_inner {
   display: inline-flex;
   flex-direction: row;
   margin: auto;
 }
 @media all and (max-width: 768px) {
-  /* line 79, ../sass/custom/_header.scss */
+  /* line 82, ../sass/custom/_header.scss */
   header .header_top_section_wrapper .header_top_section_wrapper_inner {
     display: flex;
     flex-direction: column;
@@ -10256,24 +10262,24 @@ header .header_top_section_wrapper .header_top_section_wrapper_inner {
   }
 }
 @media all and (min-width: 1051px) {
-  /* line 79, ../sass/custom/_header.scss */
+  /* line 82, ../sass/custom/_header.scss */
   header .header_top_section_wrapper .header_top_section_wrapper_inner {
     float: right;
   }
 }
-/* line 96, ../sass/custom/_header.scss */
+/* line 99, ../sass/custom/_header.scss */
 header .header_top_section_search_wrapper {
   background: #FFF;
   order: 1;
 }
-@media all and (max-width: 480px) {
-  /* line 96, ../sass/custom/_header.scss */
+@media all and (max-width: 768px) {
+  /* line 99, ../sass/custom/_header.scss */
   header .header_top_section_search_wrapper {
     order: 2;
     width: 100%;
   }
 }
-/* line 105, ../sass/custom/_header.scss */
+/* line 108, ../sass/custom/_header.scss */
 header .header_top_section_search_wrapper .cu-query {
   background: url(../images/search.svg);
   background-color: transparent;
@@ -10285,18 +10291,18 @@ header .header_top_section_search_wrapper .cu-query {
   width: 100%;
 }
 @media all and (min-width: 769px) {
-  /* line 105, ../sass/custom/_header.scss */
+  /* line 108, ../sass/custom/_header.scss */
   header .header_top_section_search_wrapper .cu-query {
     width: 250px;
   }
 }
-/* line 121, ../sass/custom/_header.scss */
+/* line 124, ../sass/custom/_header.scss */
 header .header_top_section_menu_wrapper {
   order: 3;
   z-index: 7;
 }
 @media all and (max-width: 768px) {
-  /* line 121, ../sass/custom/_header.scss */
+  /* line 124, ../sass/custom/_header.scss */
   header .header_top_section_menu_wrapper {
     align-self: flex-end;
     position: relative;
@@ -10304,14 +10310,14 @@ header .header_top_section_menu_wrapper {
   }
 }
 @media all and (max-width: 319px) {
-  /* line 121, ../sass/custom/_header.scss */
+  /* line 124, ../sass/custom/_header.scss */
   header .header_top_section_menu_wrapper {
     align-self: flex-end;
     position: relative;
     top: 50px;
   }
 }
-/* line 137, ../sass/custom/_header.scss */
+/* line 140, ../sass/custom/_header.scss */
 header .header_top_section_menu_wrapper .header_top_section_menu {
   background: #0054A6 url(../images/megamenu-icons/menu-hamburger-h.png) no-repeat 8px 50%;
   color: #FFF;
@@ -10323,11 +10329,11 @@ header .header_top_section_menu_wrapper .header_top_section_menu {
   padding: 7px 10px 6px 34px;
   text-decoration: none;
 }
-/* line 148, ../sass/custom/_header.scss */
+/* line 151, ../sass/custom/_header.scss */
 header .header_top_section_menu_wrapper .header_top_section_menu.open {
   background: #0054A6 url(../images/megamenu-icons/menu-hamburger-x.png) no-repeat 8px 50%;
 }
-/* line 154, ../sass/custom/_header.scss */
+/* line 157, ../sass/custom/_header.scss */
 header .header_logo_section {
   align-items: center;
   align-self: center;
@@ -10337,14 +10343,14 @@ header .header_logo_section {
   width: 100%;
 }
 @media all and (min-width: 769px) and (max-width: 1050px) {
-  /* line 154, ../sass/custom/_header.scss */
+  /* line 157, ../sass/custom/_header.scss */
   header .header_logo_section {
     justify-content: center;
     padding: 10px 0;
   }
 }
 @media all and (max-width: 768px) {
-  /* line 154, ../sass/custom/_header.scss */
+  /* line 157, ../sass/custom/_header.scss */
   header .header_logo_section {
     align-self: flex-end;
     margin-bottom: 20px;
@@ -10352,35 +10358,35 @@ header .header_logo_section {
   }
 }
 @media all and (max-width: 400px) {
-  /* line 172, ../sass/custom/_header.scss */
+  /* line 175, ../sass/custom/_header.scss */
   header .header_logo_section .schools_and_colleges_logo {
     margin-bottom: 16px;
   }
 }
-/* line 178, ../sass/custom/_header.scss */
+/* line 181, ../sass/custom/_header.scss */
 header .header_logo_section img {
   max-height: 60px;
   max-width: 300px;
 }
 @media all and (min-width: 1051px) {
-  /* line 184, ../sass/custom/_header.scss */
+  /* line 187, ../sass/custom/_header.scss */
   header .header_nav_section {
     align-self: flex-end;
   }
 }
 @media all and (min-width: 481px) and (max-width: 1050px) {
-  /* line 184, ../sass/custom/_header.scss */
+  /* line 187, ../sass/custom/_header.scss */
   header .header_nav_section {
     align-self: center;
   }
 }
 @media all and (max-width: 768px) {
-  /* line 184, ../sass/custom/_header.scss */
+  /* line 187, ../sass/custom/_header.scss */
   header .header_nav_section {
     display: none;
   }
 }
-/* line 196, ../sass/custom/_header.scss */
+/* line 199, ../sass/custom/_header.scss */
 header .header_nav {
   display: inline-flex;
   list-style: none;
@@ -10388,19 +10394,19 @@ header .header_nav {
   padding-left: 0;
 }
 @media all and (max-width: 768px) {
-  /* line 196, ../sass/custom/_header.scss */
+  /* line 199, ../sass/custom/_header.scss */
   header .header_nav {
     display: flex;
     flex-direction: column;
   }
 }
 @media all and (min-width: 481px) and (max-width: 1050px) {
-  /* line 196, ../sass/custom/_header.scss */
+  /* line 199, ../sass/custom/_header.scss */
   header .header_nav {
     flex-wrap: wrap;
   }
 }
-/* line 210, ../sass/custom/_header.scss */
+/* line 213, ../sass/custom/_header.scss */
 header .header_nav li {
   -webkit-transition-property: border-bottom;
   transition-property: border-bottom;
@@ -10413,12 +10419,12 @@ header .header_nav li {
   padding: 2px 6px;
 }
 @media all and (max-width: 768px) {
-  /* line 210, ../sass/custom/_header.scss */
+  /* line 213, ../sass/custom/_header.scss */
   header .header_nav li {
     display: block;
   }
 }
-/* line 223, ../sass/custom/_header.scss */
+/* line 226, ../sass/custom/_header.scss */
 header .header_nav li a {
   color: #FFF;
   font-size: 18px;
@@ -10428,82 +10434,92 @@ header .header_nav li a {
   white-space: nowrap;
 }
 @media all and (min-width: 769px) {
-  /* line 223, ../sass/custom/_header.scss */
+  /* line 226, ../sass/custom/_header.scss */
   header .header_nav li a {
     font-size: 21px;
     font-weight: 700;
     padding: 3px 8px;
   }
 }
-/* line 237, ../sass/custom/_header.scss */
+/* line 240, ../sass/custom/_header.scss */
 header .header_nav li a:hover, header .header_nav li a:focus, header .header_nav li a.active {
   border-bottom: 5px solid #019CDB;
 }
-/* line 247, ../sass/custom/_header.scss */
+/* line 250, ../sass/custom/_header.scss */
 header .mega_menu_internal_main_nav .header_nav_section {
   display: none;
 }
 @media all and (max-width: 768px) {
-  /* line 247, ../sass/custom/_header.scss */
+  /* line 250, ../sass/custom/_header.scss */
   header .mega_menu_internal_main_nav .header_nav_section {
     display: block;
   }
 }
-/* line 254, ../sass/custom/_header.scss */
+/* line 257, ../sass/custom/_header.scss */
 header .mega_menu_internal_main_nav .header_nav_section li {
   margin-bottom: 0;
   padding: 3px 0;
 }
-/* line 258, ../sass/custom/_header.scss */
+/* line 261, ../sass/custom/_header.scss */
 header .mega_menu_internal_main_nav .header_nav_section li a {
   font-family: "Open Sans Condensed", sans-serif;
   font-size: 18px;
 }
 @media all and (min-width: 769px) {
-  /* line 258, ../sass/custom/_header.scss */
+  /* line 261, ../sass/custom/_header.scss */
   header .mega_menu_internal_main_nav .header_nav_section li a {
     font-size: 21px;
   }
 }
-/* line 266, ../sass/custom/_header.scss */
+/* line 269, ../sass/custom/_header.scss */
 header .mega_menu_internal_main_nav .header_nav_section li a:hover {
   border-bottom: 1px dashed #FFF;
 }
-/* line 270, ../sass/custom/_header.scss */
+/* line 273, ../sass/custom/_header.scss */
 header .mega_menu_internal_main_nav .header_nav_section li a.active {
   border-bottom: 5px solid #019CDB;
 }
 
-/* line 279, ../sass/custom/_header.scss */
+/* line 282, ../sass/custom/_header.scss */
 ul#megamenu_icon_menu {
   padding-left: 0px;
 }
 @media all and (max-width: 480px) {
-  /* line 279, ../sass/custom/_header.scss */
+  /* line 282, ../sass/custom/_header.scss */
   ul#megamenu_icon_menu {
     margin-left: -2px;
   }
 }
 
-/* line 287, ../sass/custom/_header.scss */
+/* line 290, ../sass/custom/_header.scss */
 .transaction_menu_wrapper {
   margin: 0 4px;
   order: 3;
   padding-left: 4px;
 }
 @media all and (max-width: 768px) {
-  /* line 287, ../sass/custom/_header.scss */
+  /* line 290, ../sass/custom/_header.scss */
   .transaction_menu_wrapper {
     order: 1;
   }
 }
 @media all and (max-width: 320px) {
-  /* line 287, ../sass/custom/_header.scss */
+  /* line 290, ../sass/custom/_header.scss */
   .transaction_menu_wrapper {
     height: 70px;
   }
 }
-/* line 299, ../sass/custom/_header.scss */
+@media all and (max-width: 480px) {
+  /* line 301, ../sass/custom/_header.scss */
+  .transaction_menu_wrapper .menu--transaction-menu {
+    display: flex;
+  }
+  /* line 305, ../sass/custom/_header.scss */
+  .transaction_menu_wrapper .menu--transaction-menu li:not(:last-child) {
+    border-right: 4px solid white;
+  }
+}
+/* line 310, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li {
   background: #019CDB;
   display: inline-block;
@@ -10513,22 +10529,28 @@ ul#megamenu_icon_menu {
   margin-left: -5px;
   opacity: 1;
 }
-/* line 308, ../sass/custom/_header.scss */
+/* line 319, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li:hover {
   background: #019CDB;
 }
-/* line 312, ../sass/custom/_header.scss */
+/* line 323, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li::after {
   color: #FFF;
   content: '|';
   position: absolute;
   right: -4px;
 }
-/* line 320, ../sass/custom/_header.scss */
+/* line 331, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li:last-child::after {
   content: '';
 }
-/* line 325, ../sass/custom/_header.scss */
+@media all and (max-width: 480px) {
+  /* line 310, ../sass/custom/_header.scss */
+  .transaction_menu_wrapper li {
+    flex-grow: 1;
+  }
+}
+/* line 339, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li a {
   -webkit-transition-property: color;
   transition-property: color;
@@ -10543,20 +10565,20 @@ ul#megamenu_icon_menu {
   text-transform: uppercase;
 }
 @media all and (max-width: 768px) {
-  /* line 325, ../sass/custom/_header.scss */
+  /* line 339, ../sass/custom/_header.scss */
   .transaction_menu_wrapper li a {
     font-size: 18px;
     padding: 6px 15px 2px;
   }
 }
 @media all and (max-width: 375px) {
-  /* line 325, ../sass/custom/_header.scss */
+  /* line 339, ../sass/custom/_header.scss */
   .transaction_menu_wrapper li a {
     font-size: 18px;
     padding: 6px 10px 2px;
   }
 }
-/* line 345, ../sass/custom/_header.scss */
+/* line 359, ../sass/custom/_header.scss */
 .transaction_menu_wrapper li a:hover {
   background: #019CDB;
   color: #002E6D;

--- a/docroot/themes/custom/cu2017/sass/custom/_header.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_header.scss
@@ -15,6 +15,9 @@ header {
 		background-color: $headerBackground;
 		width: 100%;
 		z-index: 6;
+		@include respond-to(null , tablet-max){
+			margin-top: 40px;
+		}
 	}
 
 	&.header_opacity {
@@ -57,7 +60,7 @@ header {
 		position: relative;
 		text-align: center;
 		@include respond-to(null , mobile-max) {
-			background-color: white;
+			background-color:$blue;
 		}
 		@include respond-to(desktop-min , null) {
 			display: flex;
@@ -97,7 +100,7 @@ header {
 		background: $white;
 		order: 1;
 
-		@include respond-to(null , mobile-max) {
+		@include respond-to(null , tablet-max) {
 			order: 2;
 			width: 100%;
 		}
@@ -288,14 +291,22 @@ ul#megamenu_icon_menu{
 	margin: 0 4px;
 	order: 3;
 	padding-left: 4px;
-
+	
 	@include respond-to(null , tablet-max) {
 		order: 1;
 	}
 	@media all and (max-width: 320px) {
 		height: 70px;
 	}
-
+	.menu--transaction-menu{
+		@include respond-to(null , mobile-max){
+			display: flex;
+		
+			li:not(:last-child){
+				border-right:4px solid white;
+			}
+		}
+	}
 	li {
 		background: $blue;
 		display: inline-block;
@@ -320,6 +331,9 @@ ul#megamenu_icon_menu{
 			&::after {
 				content: '';
 			}
+		}
+		@include respond-to(null , mobile-max){
+			flex-grow: 1;
 		}
 
 		a {

--- a/docroot/themes/custom/cu2017/sass/custom/_megamenu.scss
+++ b/docroot/themes/custom/cu2017/sass/custom/_megamenu.scss
@@ -10,10 +10,10 @@
 	z-index: 1000;
 
 	@include respond-to(null , mobile-max)  {
-		top: $headerInnerMobileHeight;
+		top: $headerInnerMobileHeight + $headerTopBarHeight;
 	}
 	@include respond-to(tablet-min , tablet-max)  {
-		top: $headerInnerMobileHeight;
+		top: $headerInnerMobileHeight + $headerTopBarHeight;
 	}
 	@include respond-to(lg-tablet-min , lg-tablet-max) {
 		top: $headerInnerLgTabletHeight + $headerTopBarHeight;


### PR DESCRIPTION
# Description

When a transaction menu is enabled the mega menu on mobile moves to incorrect and unclicable place as well as search being hidden. This arranges transaction menu, search and header correctly. *but* only works correctly when transaction menu is enabled. It causes websites without a transaction menu to have the header lower than it should be. Last conversation there will always be a transaction menu on the sites but confirming in ticket about this. Feedback should be received on Monday.


## Todos

- verify if transaction menus will always be active

## Steps to Test or Reproduce

pull down branch
vagrant up
visit local.creighton.edu
change browser width to 480px or less
refresh the page
View header 40px lower than should be, if no transaction menu enabled
view the transaction menu, search and header stacked in that order, if transaction menu is enabled.
